### PR TITLE
fix(agent,provider): scope vault secrets + FailureDetectors for claude/cursor/codex

### DIFF
--- a/docs/explanation/apps.md
+++ b/docs/explanation/apps.md
@@ -191,6 +191,25 @@ The old `gateways` config section is replaced by `apps` in `prefs.json`:
   instances (`app.EnvKey`: `github` + `token` → `GITHUB_TOKEN`;
   `telegram:alerts` + `bot_token` → `TELEGRAM_BOT_TOKEN_ALERTS`).
 
+### Per-agent vault scoping
+
+Connected-app Secret fields and well-known integration tokens
+(`SLACK_BOT_TOKEN`, `TELEGRAM_BOT_TOKEN`, …) are **not** injected into every
+agent session. On spawn/restart, mycel looks up the agent's unmuted
+notification subscriptions (`slack:general`, `telegram:alerts:ops`, catch-all
+`slack:*`, …) and only exports credentials for matching app instances /
+platforms (#3686):
+
+| Source | Injected when |
+|---|---|
+| Role / template `secrets` allowlist | Always (unchanged) |
+| Connected-app Secret fields (`app:<instance>:<key>`) | Agent has a subscription whose instance prefix matches the app instance name (`telegram:alerts:ops` → instance `telegram:alerts`; `slack:*` → `slack`) |
+| Well-known tokens (`SLACK_BOT_TOKEN`, …) | Agent is subscribed to that platform (`slack:…` / `telegram:…`, including labeled instances) |
+| Connected GitHub `api_token` → `GH_TOKEN` / `GITHUB_TOKEN` | Agent subscribed to that github instance, **or** the role allowlist already requested `GITHUB_TOKEN` / `GH_TOKEN` |
+
+Non-secret required fields (feed URLs, homeservers, …) still inject for every
+enabled instance via `injectAppEnv` — they are not credentials.
+
 ## Server wiring
 
 `buildGatewayManager` collapses to:

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -57,6 +57,18 @@ Secrets are resolved at runtime via `${secret:NAME}` references in agent
 environment variables. The `ResolveEnv` method substitutes these references
 with decrypted values just before the agent process starts.
 
+### Agent env injection scope
+
+Vault values declared on a role or template (`secrets:`) are an **allowlist**
+for that agent only. Connected-app credentials and well-known gateway tokens
+are further scoped to agents with an unmuted notification subscription on the
+matching app instance or platform — a Slack-subscribed agent does not receive
+a Telegram bot token, and an agent with no subscriptions receives neither
+(#3686). See [Apps](apps.md#per-agent-vault-scoping) for the matching rules.
+Role allowlists still inject regardless of subscriptions, so an agent that
+needs a token without listening on that app can declare the vault name
+explicitly.
+
 ## Docker Agent Isolation
 
 When the runtime is set to `docker`, each agent runs in its own container

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1394,7 +1394,8 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	injectResourceLimits(env, existing.CPUs, existing.MemoryMB)
 	injectEnv(env, repoPath, name, existing.EnvFile, existing.Env)
 	injectAppEnv(env, m.appsConfig)
-	secretEnvKeys := injectVaultSecrets(env, repoPath, resolveAgentSecrets(repoPath, string(existing.Role), existing.Template), m.appsConfig)
+	roleSecrets := resolveAgentSecrets(repoPath, string(existing.Role), existing.Template)
+	secretEnvKeys := injectVaultSecrets(env, repoPath, roleSecrets, m.appsConfig, m.agentSubscribedChannels(ctx, name))
 
 	rt := m.runtimeForAgent(name)
 	m.mu.Unlock()
@@ -1645,7 +1646,8 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	injectResourceLimits(env, agent.CPUs, agent.MemoryMB)
 	injectEnv(env, repoPath, name, opts.EnvFile, opts.Env)
 	injectAppEnv(env, m.appsConfig)
-	secretEnvKeys := injectVaultSecrets(env, repoPath, resolveAgentSecrets(repoPath, string(role), opts.Template), m.appsConfig)
+	roleSecrets := resolveAgentSecrets(repoPath, string(role), opts.Template)
+	secretEnvKeys := injectVaultSecrets(env, repoPath, roleSecrets, m.appsConfig, m.agentSubscribedChannels(ctx, name))
 
 	rt := m.runtimeForAgent(name)
 	m.mu.Unlock()
@@ -3452,8 +3454,8 @@ func injectAppEnv(env map[string]string, apps map[string]app.InstanceConfig) {
 }
 
 // wellKnownVaultTokens lists vault secret names that are automatically injected
-// as agent env vars when present, without requiring explicit role declaration.
-// These are integration/gateway tokens that agents commonly need.
+// as agent env vars when present, without requiring explicit role declaration,
+// provided the agent is subscribed to a channel on that token's platform.
 //
 //nolint:gochecknoglobals // package-level constant slice — read-only
 var wellKnownVaultTokens = []string{
@@ -3462,6 +3464,19 @@ var wellKnownVaultTokens = []string{
 	"TELEGRAM_BOT_TOKEN",
 	"DISCORD_BOT_TOKEN",
 	"WHATSAPP_SESSION",
+}
+
+// wellKnownTokenPlatform maps a well-known vault token name to the notify
+// platform prefix that authorizes injecting it (SLACK_BOT_TOKEN → "slack").
+// Labeled instances ("telegram:alerts:…") still match platform "telegram".
+//
+//nolint:gochecknoglobals // package-level constant map — read-only
+var wellKnownTokenPlatform = map[string]string{
+	"SLACK_BOT_TOKEN":    "slack",
+	"SLACK_APP_TOKEN":    "slack",
+	"TELEGRAM_BOT_TOKEN": "telegram",
+	"DISCORD_BOT_TOKEN":  "discord",
+	"WHATSAPP_SESSION":   "whatsapp",
 }
 
 // openLayeredStore opens the global + repo vault layers and returns a
@@ -3513,22 +3528,28 @@ func openLayeredStore(repoPath, passphrase string) (ls *secret.LayeredStore, clo
 // Role-scoped and template-declared secrets (roleSecrets from ResolvedRole /
 // Template.Secrets, #3550) act as an allowlist: vault values are not sprayed
 // across every agent indiscriminately.
+//
 // Connected-app credentials (descriptor Secret fields, stored under
 // app:<instance>:<key>) and well-known integration tokens (SLACK_BOT_TOKEN
-// etc.) are also exported when present as a convenience for agents that
-// don't declare them in their role.
+// etc.) are exported only when the agent has an unmuted notification
+// subscription on that app instance / platform (#3686). subscribedChannels
+// are notify channel keys such as "slack:general", "telegram:alerts:ops",
+// or catch-all "slack:*". Pass nil/empty when the agent has no subscriptions
+// — then only roleSecrets (and the GitHub PAT vault alias below) apply.
 //
 // GITHUB_PERSONAL_ACCESS_TOKEN and GITHUB_TOKEN in the vault are aliased to
 // both GITHUB_TOKEN and GH_TOKEN so git/gh tooling works without manual wiring.
 // The connected GitHub app's api_token (app:<instance>:api_token, populated
-// by "Sign in with GitHub" or pasted manually) is aliased the same way.
+// by "Sign in with GitHub" or pasted manually) is aliased the same way, but
+// only when the agent is subscribed to that github instance or the role
+// allowlist already requested GITHUB_TOKEN/GH_TOKEN.
 //
 // Secret VALUES are never logged.
 //
 // The returned slice holds the NAMES of env keys populated from the vault
 // (never their values) so callers can summarize available credentials to the
 // agent without ever exposing the secrets themselves.
-func injectVaultSecrets(env map[string]string, repoPath string, roleSecrets []string, apps map[string]app.InstanceConfig) []string {
+func injectVaultSecrets(env map[string]string, repoPath string, roleSecrets []string, apps map[string]app.InstanceConfig, subscribedChannels []string) []string {
 	passphrase, err := secret.Passphrase()
 	if err != nil {
 		log.Warn("vault injection skipped: cannot read passphrase", "error", err)
@@ -3559,27 +3580,30 @@ func injectVaultSecrets(env map[string]string, repoPath string, roleSecrets []st
 	}
 
 	// 1. Role-declared secrets — scoped allowlist so each role controls which
-	//    vault entries it receives.
+	//    vault entries it receives. Always injected regardless of subscriptions.
 	for _, name := range roleSecrets {
 		injectIfAbsent(name, name)
 	}
+
+	roleWantsGitHub := roleRequestsGitHubToken(roleSecrets)
 
 	// 1.5. Connected-app credentials — descriptor Secret fields resolve from
 	//      the vault under app:<instance>:<key> into conventional env names
 	//      (SLACK_BOT_TOKEN, TELEGRAM_BOT_TOKEN_ALERTS, ...).
 	//
-	//      Special case: the GitHub app's "api_token" field (populated by the
-	//      device-flow "Sign in with GitHub" OAuth, or pasted manually) is
-	//      additionally aliased to GH_TOKEN/GITHUB_TOKEN so `gh` and git's
-	//      credential helper authenticate automatically — same convenience as
-	//      the GITHUB_PERSONAL_ACCESS_TOKEN vault alias below (step 3), just
-	//      sourced from a connected app instead of a hand-set vault secret.
-	//      Scoping matches every other connected-app credential here: any
-	//      enabled instance's token is available to all agents (the same
-	//      model as SLACK_BOT_TOKEN etc.) — there is no per-agent app
-	//      subscription in this codebase to scope against.
+	//      Only instances the agent is subscribed to are injected (#3686).
+	//      Role allowlist does not expand which instances are in scope here —
+	//      declare the vault names explicitly in roleSecrets if an agent needs
+	//      a token without a notification subscription.
+	//
+	//      Special case: the GitHub app's "api_token" field is additionally
+	//      aliased to GH_TOKEN/GITHUB_TOKEN when the agent is in scope for that
+	//      github instance, or when roleSecrets already requested those keys.
 	for name, ic := range apps {
 		if !ic.Enabled {
+			continue
+		}
+		if !subscribedToApp(subscribedChannels, name) {
 			continue
 		}
 		plugin, ok := app.Get(ic.App)
@@ -3598,9 +3622,30 @@ func injectVaultSecrets(env map[string]string, repoPath string, roleSecrets []st
 		}
 	}
 
-	// 2. Well-known integration tokens — convenience auto-export regardless of
-	//    role declaration so "connect once → agents have it" works out of the box.
+	// GitHub app GH_TOKEN alias when the agent is NOT subscribed to the github
+	// instance but roleSecrets requested GITHUB_TOKEN/GH_TOKEN — still allow
+	// the connected-app token to satisfy that allowlist (#3686).
+	if roleWantsGitHub {
+		for name, ic := range apps {
+			if !ic.Enabled || ic.App != "github" {
+				continue
+			}
+			if subscribedToApp(subscribedChannels, name) {
+				continue // already handled above
+			}
+			injectIfAbsent("GITHUB_TOKEN", app.SecretName(name, "api_token"))
+			injectIfAbsent("GH_TOKEN", app.SecretName(name, "api_token"))
+		}
+	}
+
+	// 2. Well-known integration tokens — auto-export when the agent is
+	//    subscribed to that platform so "connect once → subscribed agents have
+	//    it" works without spraying credentials at every session.
 	for _, name := range wellKnownVaultTokens {
+		platform := wellKnownTokenPlatform[name]
+		if platform == "" || !subscribedToPlatform(subscribedChannels, platform) {
+			continue
+		}
 		injectIfAbsent(name, name)
 	}
 
@@ -3625,6 +3670,76 @@ func injectVaultSecrets(env map[string]string, repoPath string, roleSecrets []st
 	}
 
 	return injected
+}
+
+// agentSubscribedChannels returns unmute notification channel keys for agent,
+// or nil when the channel lister is unset / errors. Used to scope vault
+// injection without coupling injectVaultSecrets to Manager (#3686).
+func (m *Manager) agentSubscribedChannels(ctx context.Context, agentName string) []string {
+	lister := m.channelLister
+	if lister == nil {
+		return nil
+	}
+	chs, err := lister.ChannelsForAgent(ctx, agentName)
+	if err != nil {
+		log.Warn("vault injection: list subscriptions failed", "agent", agentName, "error", err)
+		return nil
+	}
+	return chs
+}
+
+// channelInstancePrefix returns the app-instance prefix of a notify channel key
+// ("slack:general" → "slack", "telegram:alerts:foo" → "telegram:alerts",
+// "slack:*" → "slack"). Empty when the key has no ":" separator.
+func channelInstancePrefix(channel string) string {
+	i := strings.LastIndexByte(channel, ':')
+	if i <= 0 {
+		return ""
+	}
+	return channel[:i]
+}
+
+// subscribedToApp reports whether any subscription belongs to the given app
+// instance name. Catch-all keys like "slack:*" match instance "slack";
+// "telegram:alerts:ops" matches instance "telegram:alerts".
+func subscribedToApp(channels []string, instance string) bool {
+	if instance == "" {
+		return false
+	}
+	for _, ch := range channels {
+		if channelInstancePrefix(ch) == instance {
+			return true
+		}
+	}
+	return false
+}
+
+// subscribedToPlatform reports whether any subscription is for the given
+// platform id, including labeled instances ("telegram:alerts:…" matches
+// platform "telegram").
+func subscribedToPlatform(channels []string, platform string) bool {
+	if platform == "" {
+		return false
+	}
+	prefix := platform + ":"
+	for _, ch := range channels {
+		if strings.HasPrefix(ch, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// roleRequestsGitHubToken reports whether the role/template allowlist asked
+// for GITHUB_TOKEN or GH_TOKEN (authorizes connected-github GH_TOKEN alias
+// without a github channel subscription).
+func roleRequestsGitHubToken(roleSecrets []string) bool {
+	for _, n := range roleSecrets {
+		if n == "GITHUB_TOKEN" || n == "GH_TOKEN" {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveRoleSecrets returns the Secrets list for a named role via BFS

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1271,6 +1271,10 @@ func (m *Manager) SpawnAgentWithOptions(ctx context.Context, opts SpawnOptions) 
 // startAgent restarts an existing agent whose session has died.
 // Acquires per-agent lock internally for slow I/O; does NOT require caller to hold mu.
 func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions) (*Agent, error) {
+	// Subscription lookup hits the notify DB — do it before m.mu so a slow
+	// query cannot serialize other agent create/restart work (#3686).
+	subscribedChannels := m.agentSubscribedChannels(ctx, name)
+
 	// Phase 1: global lock — read agent state and build command config
 	m.mu.Lock()
 	existing := m.agents[name]
@@ -1395,7 +1399,7 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	injectEnv(env, repoPath, name, existing.EnvFile, existing.Env)
 	injectAppEnv(env, m.appsConfig)
 	roleSecrets := resolveAgentSecrets(repoPath, string(existing.Role), existing.Template)
-	secretEnvKeys := injectVaultSecrets(env, repoPath, roleSecrets, m.appsConfig, m.agentSubscribedChannels(ctx, name))
+	secretEnvKeys := injectVaultSecrets(env, repoPath, roleSecrets, m.appsConfig, subscribedChannels)
 
 	rt := m.runtimeForAgent(name)
 	m.mu.Unlock()
@@ -1514,6 +1518,10 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	tool := opts.Tool
 	// Worktrees come from the repo the agent is bound to, not the boot repo.
 	wtMgr := m.worktreeManagerFor(repoPath)
+
+	// Subscription lookup hits the notify DB — do it before m.mu so a slow
+	// query cannot serialize other agent create/restart work (#3686).
+	subscribedChannels := m.agentSubscribedChannels(ctx, name)
 
 	// Phase 1: global lock — build command config, register agent in map
 	m.mu.Lock()
@@ -1647,7 +1655,7 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	injectEnv(env, repoPath, name, opts.EnvFile, opts.Env)
 	injectAppEnv(env, m.appsConfig)
 	roleSecrets := resolveAgentSecrets(repoPath, string(role), opts.Template)
-	secretEnvKeys := injectVaultSecrets(env, repoPath, roleSecrets, m.appsConfig, m.agentSubscribedChannels(ctx, name))
+	secretEnvKeys := injectVaultSecrets(env, repoPath, roleSecrets, m.appsConfig, subscribedChannels)
 
 	rt := m.runtimeForAgent(name)
 	m.mu.Unlock()
@@ -3535,14 +3543,19 @@ func openLayeredStore(repoPath, passphrase string) (ls *secret.LayeredStore, clo
 // subscription on that app instance / platform (#3686). subscribedChannels
 // are notify channel keys such as "slack:general", "telegram:alerts:ops",
 // or catch-all "slack:*". Pass nil/empty when the agent has no subscriptions
-// — then only roleSecrets (and the GitHub PAT vault alias below) apply.
+// — then only roleSecrets apply (plus GitHub PAT aliases when the role
+// allowlist explicitly requested a GitHub token name).
 //
 // GITHUB_PERSONAL_ACCESS_TOKEN and GITHUB_TOKEN in the vault are aliased to
-// both GITHUB_TOKEN and GH_TOKEN so git/gh tooling works without manual wiring.
-// The connected GitHub app's api_token (app:<instance>:api_token, populated
-// by "Sign in with GitHub" or pasted manually) is aliased the same way, but
-// only when the agent is subscribed to that github instance or the role
-// allowlist already requested GITHUB_TOKEN/GH_TOKEN.
+// both GITHUB_TOKEN and GH_TOKEN so git/gh tooling works without manual wiring,
+// but only when the agent is subscribed to a github channel or the role/
+// template allowlist requested GITHUB_TOKEN, GH_TOKEN, or
+// GITHUB_PERSONAL_ACCESS_TOKEN. The connected GitHub app's api_token
+// (app:<instance>:api_token) is aliased the same way under those same
+// authorization rules; when the role allowlist authorizes GitHub without a
+// subscription, exactly one enabled github instance (or one instance named
+// via app:<instance>:api_token in roleSecrets) is used — ambiguous multi-
+// instance configs are skipped rather than picking nondeterministically.
 //
 // Secret VALUES are never logged.
 //
@@ -3586,6 +3599,7 @@ func injectVaultSecrets(env map[string]string, repoPath string, roleSecrets []st
 	}
 
 	roleWantsGitHub := roleRequestsGitHubToken(roleSecrets)
+	githubAuthorized := roleWantsGitHub || subscribedToPlatform(subscribedChannels, "github")
 
 	// 1.5. Connected-app credentials — descriptor Secret fields resolve from
 	//      the vault under app:<instance>:<key> into conventional env names
@@ -3623,18 +3637,15 @@ func injectVaultSecrets(env map[string]string, repoPath string, roleSecrets []st
 	}
 
 	// GitHub app GH_TOKEN alias when the agent is NOT subscribed to the github
-	// instance but roleSecrets requested GITHUB_TOKEN/GH_TOKEN — still allow
-	// the connected-app token to satisfy that allowlist (#3686).
+	// instance but roleSecrets requested a GitHub token — still allow the
+	// connected-app token to satisfy that allowlist (#3686). When multiple
+	// enabled github instances are unsubscribed, require an instance-specific
+	// role secret (app:<instance>:api_token) or skip — map iteration must not
+	// pick a token nondeterministically.
 	if roleWantsGitHub {
-		for name, ic := range apps {
-			if !ic.Enabled || ic.App != "github" {
-				continue
-			}
-			if subscribedToApp(subscribedChannels, name) {
-				continue // already handled above
-			}
-			injectIfAbsent("GITHUB_TOKEN", app.SecretName(name, "api_token"))
-			injectIfAbsent("GH_TOKEN", app.SecretName(name, "api_token"))
+		if instance := authorizedGitHubInstance(apps, roleSecrets, subscribedChannels); instance != "" {
+			injectIfAbsent("GITHUB_TOKEN", app.SecretName(instance, "api_token"))
+			injectIfAbsent("GH_TOKEN", app.SecretName(instance, "api_token"))
 		}
 	}
 
@@ -3651,22 +3662,26 @@ func injectVaultSecrets(env map[string]string, repoPath string, roleSecrets []st
 
 	// 3. GitHub PAT aliases: vault GITHUB_PERSONAL_ACCESS_TOKEN or GITHUB_TOKEN
 	//    is exported as both GITHUB_TOKEN and GH_TOKEN so git/gh commands work.
-	for _, src := range []string{"GITHUB_PERSONAL_ACCESS_TOKEN", "GITHUB_TOKEN"} {
-		val, e := ls.GetValue(src)
-		if e != nil || val == "" {
-			continue
+	//    Only when authorized via github subscription or explicit role/template
+	//    allowlist — never spray a global PAT into every agent session.
+	if githubAuthorized {
+		for _, src := range []string{"GITHUB_PERSONAL_ACCESS_TOKEN", "GITHUB_TOKEN"} {
+			val, e := ls.GetValue(src)
+			if e != nil || val == "" {
+				continue
+			}
+			if _, exists := env["GITHUB_TOKEN"]; !exists {
+				env["GITHUB_TOKEN"] = val
+				injected = append(injected, "GITHUB_TOKEN")
+				log.Debug("injected vault secret into agent env", "key", "GITHUB_TOKEN")
+			}
+			if _, exists := env["GH_TOKEN"]; !exists {
+				env["GH_TOKEN"] = val
+				injected = append(injected, "GH_TOKEN")
+				log.Debug("injected vault secret into agent env", "key", "GH_TOKEN")
+			}
+			break // first source wins; don't double-process
 		}
-		if _, exists := env["GITHUB_TOKEN"]; !exists {
-			env["GITHUB_TOKEN"] = val
-			injected = append(injected, "GITHUB_TOKEN")
-			log.Debug("injected vault secret into agent env", "key", "GITHUB_TOKEN")
-		}
-		if _, exists := env["GH_TOKEN"]; !exists {
-			env["GH_TOKEN"] = val
-			injected = append(injected, "GH_TOKEN")
-			log.Debug("injected vault secret into agent env", "key", "GH_TOKEN")
-		}
-		break // first source wins; don't double-process
 	}
 
 	return injected
@@ -3731,15 +3746,71 @@ func subscribedToPlatform(channels []string, platform string) bool {
 }
 
 // roleRequestsGitHubToken reports whether the role/template allowlist asked
-// for GITHUB_TOKEN or GH_TOKEN (authorizes connected-github GH_TOKEN alias
-// without a github channel subscription).
+// for a GitHub credential. That authorizes connected-github GH_TOKEN aliasing
+// and vault PAT aliases without a github channel subscription.
 func roleRequestsGitHubToken(roleSecrets []string) bool {
 	for _, n := range roleSecrets {
-		if n == "GITHUB_TOKEN" || n == "GH_TOKEN" {
+		switch n {
+		case "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PERSONAL_ACCESS_TOKEN":
+			return true
+		}
+		if isGitHubAppAPITokenSecret(n) {
 			return true
 		}
 	}
 	return false
+}
+
+// isGitHubAppAPITokenSecret reports whether name is a connected GitHub app
+// api_token vault key (app:github:api_token or app:github:<label>:api_token).
+func isGitHubAppAPITokenSecret(name string) bool {
+	if !strings.HasPrefix(name, "app:") || !strings.HasSuffix(name, ":api_token") {
+		return false
+	}
+	inst := strings.TrimSuffix(strings.TrimPrefix(name, "app:"), ":api_token")
+	return inst == "github" || strings.HasPrefix(inst, "github:")
+}
+
+// authorizedGitHubInstance picks which enabled, unsubscribed github app
+// instance may satisfy a role-authorized GH_TOKEN alias. Returns "" when
+// none apply or when multiple enabled instances would make the choice
+// ambiguous without an instance-specific role secret.
+func authorizedGitHubInstance(apps map[string]app.InstanceConfig, roleSecrets []string, subscribedChannels []string) string {
+	var candidates []string
+	for name, ic := range apps {
+		if !ic.Enabled || ic.App != "github" {
+			continue
+		}
+		if subscribedToApp(subscribedChannels, name) {
+			continue // already handled via subscription path
+		}
+		candidates = append(candidates, name)
+	}
+	if len(candidates) == 0 {
+		return ""
+	}
+
+	// Prefer instances the allowlist named explicitly via app:<instance>:api_token.
+	var named []string
+	for _, name := range candidates {
+		want := app.SecretName(name, "api_token")
+		for _, rs := range roleSecrets {
+			if rs == want {
+				named = append(named, name)
+				break
+			}
+		}
+	}
+	if len(named) == 1 {
+		return named[0]
+	}
+	if len(named) > 1 {
+		return "" // still ambiguous among explicitly named instances
+	}
+	if len(candidates) == 1 {
+		return candidates[0]
+	}
+	return "" // multiple enabled instances, no instance-specific allowlist entry
 }
 
 // resolveRoleSecrets returns the Secrets list for a named role via BFS

--- a/pkg/agent/template_secrets_test.go
+++ b/pkg/agent/template_secrets_test.go
@@ -100,7 +100,7 @@ func TestTemplateSecretsInjectIntoAgentEnv(t *testing.T) {
 
 	names := resolveAgentSecrets(t.TempDir(), "", "trader")
 	env := map[string]string{}
-	injected := injectVaultSecrets(env, t.TempDir(), names, nil)
+	injected := injectVaultSecrets(env, t.TempDir(), names, nil, nil)
 	if env["ALPACA_KEY"] != "sk-live-test" {
 		t.Fatalf("env ALPACA_KEY = %q, injected=%v", env["ALPACA_KEY"], injected)
 	}

--- a/pkg/agent/vault_inject_test.go
+++ b/pkg/agent/vault_inject_test.go
@@ -141,6 +141,21 @@ func TestInjectVaultSecrets(t *testing.T) {
 			wantKey:     "GITHUB_TOKEN",
 			wantValue:   "existing-gh-token",
 		},
+		{
+			name:        "GITHUB_PAT alias skipped without role or github subscription",
+			preEnv:      map[string]string{},
+			roleSecrets: nil,
+			channels:    []string{"slack:general"},
+			wantAbsent:  []string{"GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PERSONAL_ACCESS_TOKEN"},
+		},
+		{
+			name:        "GITHUB_PAT aliased for github subscriber without role allowlist",
+			preEnv:      map[string]string{},
+			roleSecrets: nil,
+			channels:    []string{"github:*"},
+			wantKey:     "GITHUB_TOKEN",
+			wantValue:   "ghp-token-123",
+		},
 	}
 
 	for _, tc := range tests {
@@ -331,6 +346,42 @@ func TestInjectVaultSecrets_GitHubAppToken(t *testing.T) {
 		}
 		if _, ok := env["GITHUB_TOKEN"]; ok {
 			t.Error("GITHUB_TOKEN should be absent with no apps configured")
+		}
+	})
+
+	t.Run("ambiguous multi-instance role allowlist skips GH_TOKEN", func(t *testing.T) {
+		seedRepoVault(t, repoPath, "app:github:work:api_token", "gho_work")
+		seedRepoVault(t, repoPath, "app:github:personal:api_token", "gho_personal")
+		apps := map[string]app.InstanceConfig{
+			"github:work":     {App: "github", Enabled: true},
+			"github:personal": {App: "github", Enabled: true},
+		}
+		env := map[string]string{}
+		injectVaultSecrets(env, repoPath, []string{"GH_TOKEN"}, apps, nil)
+
+		if _, ok := env["GH_TOKEN"]; ok {
+			t.Error("GH_TOKEN must not inject when multiple github instances are ambiguous")
+		}
+		if _, ok := env["GITHUB_TOKEN"]; ok {
+			t.Error("GITHUB_TOKEN must not inject when multiple github instances are ambiguous")
+		}
+	})
+
+	t.Run("instance-specific role secret picks that github instance", func(t *testing.T) {
+		seedRepoVault(t, repoPath, "app:github:work:api_token", "gho_work_only")
+		seedRepoVault(t, repoPath, "app:github:personal:api_token", "gho_personal_skip")
+		apps := map[string]app.InstanceConfig{
+			"github:work":     {App: "github", Enabled: true},
+			"github:personal": {App: "github", Enabled: true},
+		}
+		env := map[string]string{}
+		injectVaultSecrets(env, repoPath, []string{"app:github:work:api_token"}, apps, nil)
+
+		if env["GH_TOKEN"] != "gho_work_only" {
+			t.Errorf("GH_TOKEN = %q, want gho_work_only from named instance", env["GH_TOKEN"])
+		}
+		if env["GITHUB_TOKEN"] != "gho_work_only" {
+			t.Errorf("GITHUB_TOKEN = %q, want gho_work_only from named instance", env["GITHUB_TOKEN"])
 		}
 	})
 }

--- a/pkg/agent/vault_inject_test.go
+++ b/pkg/agent/vault_inject_test.go
@@ -87,7 +87,7 @@ func TestInjectVaultSecrets(t *testing.T) {
 			wantValue:   "h-wins",
 		},
 		{
-			name: "well-known gateway token auto-injected for slack subscriber",
+			name:   "well-known gateway token auto-injected for slack subscriber",
 			preEnv: map[string]string{},
 			// SLACK_BOT_TOKEN not in roleSecrets — inject via wellKnownVaultTokens
 			// only when subscribed to a slack channel (#3686).

--- a/pkg/agent/vault_inject_test.go
+++ b/pkg/agent/vault_inject_test.go
@@ -60,6 +60,7 @@ func TestInjectVaultSecrets(t *testing.T) {
 		name        string
 		preEnv      map[string]string // env already set before injection
 		roleSecrets []string
+		channels    []string
 		wantKey     string
 		wantValue   string
 		wantAbsent  []string
@@ -86,12 +87,21 @@ func TestInjectVaultSecrets(t *testing.T) {
 			wantValue:   "h-wins",
 		},
 		{
-			name:   "well-known gateway token auto-injected without role declaration",
+			name: "well-known gateway token auto-injected for slack subscriber",
 			preEnv: map[string]string{},
-			// SLACK_BOT_TOKEN not in roleSecrets — should still inject via wellKnownVaultTokens
+			// SLACK_BOT_TOKEN not in roleSecrets — inject via wellKnownVaultTokens
+			// only when subscribed to a slack channel (#3686).
 			roleSecrets: nil,
+			channels:    []string{"slack:general"},
 			wantKey:     "SLACK_BOT_TOKEN",
 			wantValue:   "slack-h-token",
+		},
+		{
+			name:        "well-known token skipped for non-subscriber",
+			preEnv:      map[string]string{},
+			roleSecrets: nil,
+			channels:    []string{"telegram:ops"},
+			wantAbsent:  []string{"SLACK_BOT_TOKEN"},
 		},
 		{
 			name: "existing env wins over vault (precedence)",
@@ -140,7 +150,7 @@ func TestInjectVaultSecrets(t *testing.T) {
 				env[k] = v
 			}
 
-			injectVaultSecrets(env, repoPath, tc.roleSecrets, nil)
+			injectVaultSecrets(env, repoPath, tc.roleSecrets, nil, tc.channels)
 
 			if tc.wantKey != "" {
 				if got := env[tc.wantKey]; got != tc.wantValue {
@@ -158,7 +168,7 @@ func TestInjectVaultSecrets(t *testing.T) {
 
 // TestInjectVaultSecretsAppCredentials proves connected-app credentials
 // stored under app:<instance>:<key> are exported under their conventional
-// env names, driven by the app descriptor's Secret fields.
+// env names only for agents subscribed to that instance (#3686).
 func TestInjectVaultSecretsAppCredentials(t *testing.T) {
 	mycelHome := t.TempDir()
 	t.Setenv("MYCEL_HOME", mycelHome)
@@ -176,32 +186,61 @@ func TestInjectVaultSecretsAppCredentials(t *testing.T) {
 		"rss:blog":        {App: "rss", Enabled: true, Config: map[string]string{"url": "https://x/feed"}},
 	}
 
-	env := map[string]string{}
-	injected := injectVaultSecrets(env, repoPath, nil, apps)
+	t.Run("subscriber receives matching instance secrets", func(t *testing.T) {
+		env := map[string]string{}
+		injected := injectVaultSecrets(env, repoPath, nil, apps, []string{
+			"slack:general",
+			"telegram:alerts:ops",
+		})
 
-	if env["SLACK_BOT_TOKEN"] != "xoxb-app-vault" {
-		t.Errorf("SLACK_BOT_TOKEN = %q, want xoxb-app-vault", env["SLACK_BOT_TOKEN"])
-	}
-	if env["TELEGRAM_BOT_TOKEN_ALERTS"] != "tg-app-vault" {
-		t.Errorf("TELEGRAM_BOT_TOKEN_ALERTS = %q, want tg-app-vault", env["TELEGRAM_BOT_TOKEN_ALERTS"])
-	}
-	if _, ok := env["TELEGRAM_BOT_TOKEN_OFF"]; ok {
-		t.Error("disabled instance credential must not be injected")
-	}
-	if _, ok := env["RSS_URL_BLOG"]; ok {
-		t.Error("non-secret field must not be injected from the vault")
-	}
-	if len(injected) == 0 {
-		t.Error("injected key names should be reported")
-	}
+		if env["SLACK_BOT_TOKEN"] != "xoxb-app-vault" {
+			t.Errorf("SLACK_BOT_TOKEN = %q, want xoxb-app-vault", env["SLACK_BOT_TOKEN"])
+		}
+		if env["TELEGRAM_BOT_TOKEN_ALERTS"] != "tg-app-vault" {
+			t.Errorf("TELEGRAM_BOT_TOKEN_ALERTS = %q, want tg-app-vault", env["TELEGRAM_BOT_TOKEN_ALERTS"])
+		}
+		if _, ok := env["TELEGRAM_BOT_TOKEN_OFF"]; ok {
+			t.Error("disabled instance credential must not be injected")
+		}
+		if _, ok := env["RSS_URL_BLOG"]; ok {
+			t.Error("non-secret field must not be injected from the vault")
+		}
+		if len(injected) == 0 {
+			t.Error("injected key names should be reported")
+		}
+	})
+
+	t.Run("non-subscriber excluded from other instances", func(t *testing.T) {
+		env := map[string]string{}
+		injectVaultSecrets(env, repoPath, nil, apps, []string{"slack:*"})
+
+		if env["SLACK_BOT_TOKEN"] != "xoxb-app-vault" {
+			t.Errorf("SLACK_BOT_TOKEN = %q, want xoxb-app-vault for slack subscriber", env["SLACK_BOT_TOKEN"])
+		}
+		if _, ok := env["TELEGRAM_BOT_TOKEN_ALERTS"]; ok {
+			t.Error("telegram:alerts secret must not inject for a slack-only subscriber")
+		}
+	})
+
+	t.Run("no subscriptions yields no connected-app secrets", func(t *testing.T) {
+		env := map[string]string{}
+		injectVaultSecrets(env, repoPath, nil, apps, nil)
+
+		if _, ok := env["SLACK_BOT_TOKEN"]; ok {
+			t.Error("SLACK_BOT_TOKEN must not inject without a slack subscription")
+		}
+		if _, ok := env["TELEGRAM_BOT_TOKEN_ALERTS"]; ok {
+			t.Error("TELEGRAM_BOT_TOKEN_ALERTS must not inject without a telegram:alerts subscription")
+		}
+	})
 }
 
 // TestInjectVaultSecrets_GitHubAppToken proves a connected GitHub app
 // instance's api_token (as populated by the device-flow "Sign in with
-// GitHub", or pasted manually) is made available to agents as both
-// GH_TOKEN and GITHUB_TOKEN — so `gh` and git's credential helper
+// GitHub", or pasted manually) is made available to subscribed agents as
+// both GH_TOKEN and GITHUB_TOKEN — so `gh` and git's credential helper
 // authenticate with zero per-agent setup — while an agent with no
-// connected GitHub app instance gets neither key.
+// github subscription and no role allowlist gets neither key (#3686).
 func TestInjectVaultSecrets_GitHubAppToken(t *testing.T) {
 	mycelHome := t.TempDir()
 	t.Setenv("MYCEL_HOME", mycelHome)
@@ -210,12 +249,12 @@ func TestInjectVaultSecrets_GitHubAppToken(t *testing.T) {
 	repoPath := t.TempDir()
 	seedRepoVault(t, repoPath, "app:github:api_token", "gho_devflow_token")
 
-	t.Run("connected instance yields GH_TOKEN and GITHUB_TOKEN", func(t *testing.T) {
+	t.Run("subscribed agent yields GH_TOKEN and GITHUB_TOKEN", func(t *testing.T) {
 		apps := map[string]app.InstanceConfig{
 			"github": {App: "github", Enabled: true},
 		}
 		env := map[string]string{}
-		injected := injectVaultSecrets(env, repoPath, nil, apps)
+		injected := injectVaultSecrets(env, repoPath, nil, apps, []string{"github:*"})
 
 		if env["GH_TOKEN"] != "gho_devflow_token" {
 			t.Errorf("GH_TOKEN = %q, want gho_devflow_token", env["GH_TOKEN"])
@@ -238,12 +277,42 @@ func TestInjectVaultSecrets_GitHubAppToken(t *testing.T) {
 		}
 	})
 
+	t.Run("role allowlist aliases without github subscription", func(t *testing.T) {
+		apps := map[string]app.InstanceConfig{
+			"github": {App: "github", Enabled: true},
+		}
+		env := map[string]string{}
+		injectVaultSecrets(env, repoPath, []string{"GH_TOKEN"}, apps, nil)
+
+		if env["GH_TOKEN"] != "gho_devflow_token" {
+			t.Errorf("GH_TOKEN = %q, want gho_devflow_token via role allowlist", env["GH_TOKEN"])
+		}
+		if env["GITHUB_TOKEN"] != "gho_devflow_token" {
+			t.Errorf("GITHUB_TOKEN = %q, want gho_devflow_token via role allowlist", env["GITHUB_TOKEN"])
+		}
+	})
+
+	t.Run("non-subscriber without role allowlist yields neither key", func(t *testing.T) {
+		apps := map[string]app.InstanceConfig{
+			"github": {App: "github", Enabled: true},
+		}
+		env := map[string]string{}
+		injectVaultSecrets(env, repoPath, nil, apps, []string{"slack:general"})
+
+		if _, ok := env["GH_TOKEN"]; ok {
+			t.Error("GH_TOKEN should be absent without github scope")
+		}
+		if _, ok := env["GITHUB_TOKEN"]; ok {
+			t.Error("GITHUB_TOKEN should be absent without github scope")
+		}
+	})
+
 	t.Run("disabled instance yields neither key", func(t *testing.T) {
 		apps := map[string]app.InstanceConfig{
 			"github": {App: "github", Enabled: false},
 		}
 		env := map[string]string{}
-		injectVaultSecrets(env, repoPath, nil, apps)
+		injectVaultSecrets(env, repoPath, nil, apps, []string{"github:*"})
 
 		if _, ok := env["GH_TOKEN"]; ok {
 			t.Error("GH_TOKEN should be absent when no github app instance is enabled")
@@ -255,7 +324,7 @@ func TestInjectVaultSecrets_GitHubAppToken(t *testing.T) {
 
 	t.Run("no github app configured yields neither key", func(t *testing.T) {
 		env := map[string]string{}
-		injectVaultSecrets(env, repoPath, nil, nil)
+		injectVaultSecrets(env, repoPath, nil, nil, nil)
 
 		if _, ok := env["GH_TOKEN"]; ok {
 			t.Error("GH_TOKEN should be absent with no apps configured")
@@ -264,6 +333,28 @@ func TestInjectVaultSecrets_GitHubAppToken(t *testing.T) {
 			t.Error("GITHUB_TOKEN should be absent with no apps configured")
 		}
 	})
+}
+
+func TestSubscribedToAppAndPlatform(t *testing.T) {
+	channels := []string{"slack:general", "slack:*", "telegram:alerts:ops", "telegram:alerts:*"}
+	if !subscribedToApp(channels, "slack") {
+		t.Error("want subscribedToApp(slack)")
+	}
+	if !subscribedToApp(channels, "telegram:alerts") {
+		t.Error("want subscribedToApp(telegram:alerts)")
+	}
+	if subscribedToApp(channels, "discord") {
+		t.Error("discord must not match")
+	}
+	if !subscribedToPlatform(channels, "slack") {
+		t.Error("want subscribedToPlatform(slack)")
+	}
+	if !subscribedToPlatform(channels, "telegram") {
+		t.Error("labeled telegram:alerts:* must still match platform telegram")
+	}
+	if subscribedToPlatform(channels, "discord") {
+		t.Error("discord platform must not match")
+	}
 }
 
 // TestAppEnvAndPromptInstructions covers plain-field env injection and the

--- a/pkg/provider/claude_failure.go
+++ b/pkg/provider/claude_failure.go
@@ -1,0 +1,53 @@
+package provider
+
+// claudeFatalPatterns are Claude Code's refusals to serve a turn at all.
+//
+// Taken from the Claude Code CLI's own error strings (credit/auth/model
+// refusals that leave the prompt up with nothing for the transcript tailer
+// to observe). LineStartsWith is Claude's own marker so an agent discussing
+// these strings is not reported broken (#3687).
+var claudeFatalPatterns = []FailurePattern{
+	{
+		// "API Error: 401 Invalid API key · Please run /login"
+		LineStartsWith: "api error:",
+		Contains:       "invalid api key",
+		Reason:         "claude has an invalid API key — run /login in the agent's terminal or fix ANTHROPIC_API_KEY",
+	},
+	{
+		// "Not logged in · Please run /login"
+		// "Not logged in. Run claude auth login to authenticate."
+		LineStartsWith: "not logged in",
+		Contains:       "login",
+		Reason:         "claude is not logged in — run /login in the agent's terminal",
+	},
+	{
+		// "Failed to authenticate. · Please run /login"
+		// "Please run /login · …"
+		LineStartsWith: "failed to authenticate",
+		Contains:       "authenticate",
+		Reason:         "claude failed to authenticate — run /login in the agent's terminal",
+	},
+	{
+		// "Credit balance is too low"
+		LineStartsWith: "credit balance is too low",
+		Contains:       "credit balance is too low",
+		Reason:         "claude's credit balance is too low — add credits or switch accounts",
+	},
+	{
+		// "API Error: … usage limit reached …"
+		LineStartsWith: "api error:",
+		Contains:       "usage limit reached",
+		Reason:         "claude's usage limit is exhausted — wait for reset or upgrade the plan",
+	},
+	{
+		// "Claude Opus is not available with the Claude Pro plan. …"
+		LineStartsWith: "claude opus is not available",
+		Contains:       "not available",
+		Reason:         "claude's model is unavailable on this plan — pick another model for this agent",
+	},
+}
+
+// DetectFailure implements FailureDetector.
+func (p *ClaudeProvider) DetectFailure(pane string) (string, bool) {
+	return MatchFailure(pane, paneTailLines, claudeFatalPatterns)
+}

--- a/pkg/provider/codex_failure.go
+++ b/pkg/provider/codex_failure.go
@@ -1,0 +1,52 @@
+package provider
+
+// codexFatalPatterns are Codex CLI's refusals to serve a turn at all.
+//
+// Taken from the Codex binary's own auth/quota/access messages. Codex often
+// prints the failure as the start of the line (no "Error:" prefix), so the
+// marker is the beginning of that message — an agent discussing the same
+// prose under a tool bullet will not match (#3687).
+var codexFatalPatterns = []FailurePattern{
+	{
+		// "no Codex credentials were found"
+		// "Run codex login or provide an API key through a supported auth env var."
+		LineStartsWith: "no codex credentials were found",
+		Contains:       "no codex credentials were found",
+		Reason:         "codex has no credentials — run codex login or set OPENAI_API_KEY",
+	},
+	{
+		// "Not signed in. Please run 'codex login' to sign in with ChatGPT, …"
+		LineStartsWith: "not signed in",
+		Contains:       "codex login",
+		Reason:         "codex is not signed in — run codex login in the agent's terminal",
+	},
+	{
+		// "You're out of credits. Your workspace is out of credits. …"
+		LineStartsWith: "you're out of credits",
+		Contains:       "out of credits",
+		Reason:         "codex is out of credits — add credits or switch workspaces",
+	},
+	{
+		// "Usage limit reached. You've reached your usage limit. …"
+		LineStartsWith: "usage limit reached",
+		Contains:       "usage limit",
+		Reason:         "codex's usage limit is exhausted — wait for reset or raise the limit",
+	},
+	{
+		// "You do not have access to Codex"
+		LineStartsWith: "you do not have access to codex",
+		Contains:       "do not have access",
+		Reason:         "this account cannot use Codex — switch accounts or ask a workspace admin",
+	},
+	{
+		// "Unknown model `…` for spawn_agent. Available models: …"
+		LineStartsWith: "unknown model",
+		Contains:       "unknown model",
+		Reason:         "codex's model is unavailable — pick another model for this agent",
+	},
+}
+
+// DetectFailure implements FailureDetector.
+func (p *CodexProvider) DetectFailure(pane string) (string, bool) {
+	return MatchFailure(pane, paneTailLines, codexFatalPatterns)
+}

--- a/pkg/provider/cursor_failure.go
+++ b/pkg/provider/cursor_failure.go
@@ -1,0 +1,44 @@
+package provider
+
+// cursorFatalPatterns are Cursor Agent's refusals to serve a turn at all.
+//
+// Taken from cursor-agent's own auth/error lines (missing login, invalid
+// CURSOR_API_KEY, failed model load). LineStartsWith is the CLI's marker so
+// an agent discussing these strings is not reported broken (#3687).
+var cursorFatalPatterns = []FailurePattern{
+	{
+		// "Error: Authentication required. Please run 'agent login' first, or set CURSOR_API_KEY environment variable."
+		LineStartsWith: "error:",
+		Contains:       "authentication required",
+		Reason:         "cursor is not authenticated — run agent login or set CURSOR_API_KEY",
+	},
+	{
+		// "Authentication required to use Cursor Agent. Please run 'agent login' to authenticate."
+		LineStartsWith: "authentication required",
+		Contains:       "login",
+		Reason:         "cursor is not authenticated — run agent login or set CURSOR_API_KEY",
+	},
+	{
+		// "Authentication failed: your Cursor credentials or API key are invalid or expired."
+		LineStartsWith: "authentication failed:",
+		Contains:       "api key",
+		Reason:         "cursor credentials or API key are invalid — run agent login or fix CURSOR_API_KEY",
+	},
+	{
+		// "Not logged in. Run `agent login` first."
+		LineStartsWith: "not logged in",
+		Contains:       "login",
+		Reason:         "cursor is not logged in — run agent login in the agent's terminal",
+	},
+	{
+		// "Failed to load models: …" after an auth/entitlement failure
+		LineStartsWith: "failed to load models:",
+		Contains:       "failed to load models",
+		Reason:         "cursor could not load models — check auth and model access for this account",
+	},
+}
+
+// DetectFailure implements FailureDetector.
+func (p *CursorProvider) DetectFailure(pane string) (string, bool) {
+	return MatchFailure(pane, paneTailLines, cursorFatalPatterns)
+}

--- a/pkg/provider/failure_test.go
+++ b/pkg/provider/failure_test.go
@@ -53,6 +53,7 @@ const cursorBadKeyPane = `Authentication failed: your Cursor credentials or API 
 If you set CURSOR_API_KEY, check that it is correct, or run ` + "`agent login`" + ` to re-authenticate.
 `
 
+//nolint:gosec // G101: quoted CLI error text, not a credential
 const codexNoCredsPane = `no Codex credentials were found
 Run codex login or provide an API key through a supported auth env var.
 `

--- a/pkg/provider/failure_test.go
+++ b/pkg/provider/failure_test.go
@@ -33,11 +33,44 @@ Error ID: 08a716f9-72a7-45b4-b26f-b2de551b857f-302
 > hi
 ? for shortcuts                                    Gemini 3.5 Flash · medium`
 
+// Claude / Cursor / Codex panes mirror the CLIs' own fatal lines (#3687).
+const claudeNoKeyPane = `────────────────────────────────────────────────────────────────────────
+ API Error: 401 Invalid API key · Please run /login
+────────────────────────────────────────────────────────────────────────
+ > `
+
+const claudeCreditPane = ` Credit balance is too low
+ Add credits at https://console.anthropic.com
+ > `
+
+const claudeNotLoggedInPane = ` Not logged in · Please run /login
+ > `
+
+const cursorAuthPane = `Error: Authentication required. Please run 'agent login' first, or set CURSOR_API_KEY environment variable.
+`
+
+const cursorBadKeyPane = `Authentication failed: your Cursor credentials or API key are invalid or expired.
+If you set CURSOR_API_KEY, check that it is correct, or run ` + "`agent login`" + ` to re-authenticate.
+`
+
+const codexNoCredsPane = `no Codex credentials were found
+Run codex login or provide an API key through a supported auth env var.
+`
+
+const codexOutOfCreditsPane = `You're out of credits. Your workspace is out of credits. Add credits to continue using Codex.
+`
+
+const codexNoAccessPane = `You do not have access to Codex
+This account is not currently authorized to use Codex in this workspace.
+`
+
 // A healthy pane, including one that talks about the very things the patterns
 // look for. An agent editing provider code must never be reported as broken.
 const workingPane = `● Read pkg/provider/pi.go
 ● The API key handling looks right. No API key found for is the error string
   we match on, so the test should assert that exact text.
+● Also discussing markers like "Authentication required", "credit balance is too low",
+  and the phrase "no Codex credentials were found" mid-sentence only.
 ● Bash(go test ./pkg/provider/)
   ok  github.com/rpuneet/mycel/pkg/provider  0.412s
 > `
@@ -84,6 +117,87 @@ func TestAgyDetectFailure(t *testing.T) {
 
 	if _, failed := p.DetectFailure(workingPane); failed {
 		t.Error("a working agent must not be reported as failed")
+	}
+}
+
+func TestClaudeDetectFailure(t *testing.T) {
+	p := &ClaudeProvider{}
+	tests := []struct {
+		name       string
+		pane       string
+		wantIn     string
+		wantFailed bool
+	}{
+		{"invalid api key", claudeNoKeyPane, "API key", true},
+		{"credit balance", claudeCreditPane, "credit", true},
+		{"not logged in", claudeNotLoggedInPane, "not logged in", true},
+		{"working agent", workingPane, "", false},
+		{"empty pane", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, failed := p.DetectFailure(tt.pane)
+			if failed != tt.wantFailed {
+				t.Fatalf("failed = %v, want %v (reason %q)", failed, tt.wantFailed, reason)
+			}
+			if tt.wantIn != "" && !strings.Contains(reason, tt.wantIn) {
+				t.Errorf("reason = %q, want it to mention %q", reason, tt.wantIn)
+			}
+			if !tt.wantFailed && reason != "" {
+				t.Errorf("reason = %q, want empty when not failed", reason)
+			}
+		})
+	}
+}
+
+func TestCursorDetectFailure(t *testing.T) {
+	p := &CursorProvider{}
+	tests := []struct {
+		name       string
+		pane       string
+		wantIn     string
+		wantFailed bool
+	}{
+		{"auth required", cursorAuthPane, "not authenticated", true},
+		{"bad api key", cursorBadKeyPane, "API key", true},
+		{"working agent", workingPane, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, failed := p.DetectFailure(tt.pane)
+			if failed != tt.wantFailed {
+				t.Fatalf("failed = %v, want %v (reason %q)", failed, tt.wantFailed, reason)
+			}
+			if tt.wantIn != "" && !strings.Contains(reason, tt.wantIn) {
+				t.Errorf("reason = %q, want it to mention %q", reason, tt.wantIn)
+			}
+		})
+	}
+}
+
+func TestCodexDetectFailure(t *testing.T) {
+	p := &CodexProvider{}
+	tests := []struct {
+		name       string
+		pane       string
+		wantIn     string
+		wantFailed bool
+	}{
+		{"no credentials", codexNoCredsPane, "credentials", true},
+		{"out of credits", codexOutOfCreditsPane, "credits", true},
+		{"no access", codexNoAccessPane, "cannot use Codex", true},
+		{"working agent", workingPane, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, failed := p.DetectFailure(tt.pane)
+			if failed != tt.wantFailed {
+				t.Fatalf("failed = %v, want %v (reason %q)", failed, tt.wantFailed, reason)
+			}
+			if tt.wantIn != "" && !strings.Contains(reason, tt.wantIn) {
+				t.Errorf("reason = %q, want it to mention %q", reason, tt.wantIn)
+			}
+		})
 	}
 }
 
@@ -206,6 +320,9 @@ func TestProvidersImplementFailureDetector(t *testing.T) {
 	}{
 		{&PiProvider{}, "pi"},
 		{&AgyProvider{}, "agy"},
+		{&ClaudeProvider{}, "claude"},
+		{&CursorProvider{}, "cursor"},
+		{&CodexProvider{}, "codex"},
 	} {
 		if _, ok := tt.p.(FailureDetector); !ok {
 			t.Errorf("%s does not implement FailureDetector", tt.name)

--- a/pkg/provider/failure_test.go
+++ b/pkg/provider/failure_test.go
@@ -46,11 +46,25 @@ const claudeCreditPane = ` Credit balance is too low
 const claudeNotLoggedInPane = ` Not logged in · Please run /login
  > `
 
+const claudeUsageLimitPane = `────────────────────────────────────────────────────────────────────────
+ API Error: 429 usage limit reached · resets at 3pm
+────────────────────────────────────────────────────────────────────────
+ > `
+
+const claudeModelUnavailablePane = ` Claude Opus is not available with the Claude Pro plan. Please use Sonnet or upgrade.
+ > `
+
 const cursorAuthPane = `Error: Authentication required. Please run 'agent login' first, or set CURSOR_API_KEY environment variable.
 `
 
 const cursorBadKeyPane = `Authentication failed: your Cursor credentials or API key are invalid or expired.
 If you set CURSOR_API_KEY, check that it is correct, or run ` + "`agent login`" + ` to re-authenticate.
+`
+
+const cursorNotLoggedInPane = `Not logged in. Run ` + "`agent login`" + ` first.
+`
+
+const cursorModelLoadPane = `Failed to load models: authentication required or model access denied for this account.
 `
 
 //nolint:gosec // G101: quoted CLI error text, not a credential
@@ -64,6 +78,14 @@ const codexOutOfCreditsPane = `You're out of credits. Your workspace is out of c
 const codexNoAccessPane = `You do not have access to Codex
 This account is not currently authorized to use Codex in this workspace.
 `
+
+const codexNotSignedInPane = `Not signed in. Please run 'codex login' to sign in with ChatGPT, or provide an API key.
+`
+
+const codexUsageLimitPane = `Usage limit reached. You've reached your usage limit. Try again later or raise the limit.
+`
+
+const codexUnknownModelPane = "Unknown model `gpt-imaginary` for spawn_agent. Available models: gpt-5, o3.\n"
 
 // A healthy pane, including one that talks about the very things the patterns
 // look for. An agent editing provider code must never be reported as broken.
@@ -132,6 +154,8 @@ func TestClaudeDetectFailure(t *testing.T) {
 		{"invalid api key", claudeNoKeyPane, "API key", true},
 		{"credit balance", claudeCreditPane, "credit", true},
 		{"not logged in", claudeNotLoggedInPane, "not logged in", true},
+		{"usage limit", claudeUsageLimitPane, "usage limit", true},
+		{"model unavailable", claudeModelUnavailablePane, "model is unavailable", true},
 		{"working agent", workingPane, "", false},
 		{"empty pane", "", "", false},
 	}
@@ -161,6 +185,8 @@ func TestCursorDetectFailure(t *testing.T) {
 	}{
 		{"auth required", cursorAuthPane, "not authenticated", true},
 		{"bad api key", cursorBadKeyPane, "API key", true},
+		{"not logged in", cursorNotLoggedInPane, "not logged in", true},
+		{"failed to load models", cursorModelLoadPane, "could not load models", true},
 		{"working agent", workingPane, "", false},
 	}
 	for _, tt := range tests {
@@ -187,6 +213,9 @@ func TestCodexDetectFailure(t *testing.T) {
 		{"no credentials", codexNoCredsPane, "credentials", true},
 		{"out of credits", codexOutOfCreditsPane, "credits", true},
 		{"no access", codexNoAccessPane, "cannot use Codex", true},
+		{"not signed in", codexNotSignedInPane, "not signed in", true},
+		{"usage limit", codexUsageLimitPane, "usage limit", true},
+		{"unknown model", codexUnknownModelPane, "model is unavailable", true},
 		{"working agent", workingPane, "", false},
 	}
 	for _, tt := range tests {

--- a/server/provider_failure_monitor_test.go
+++ b/server/provider_failure_monitor_test.go
@@ -200,11 +200,13 @@ func TestSweepIgnoresAgentsWhoseTerminalCannotBeRead(t *testing.T) {
 
 func TestSweepIgnoresProvidersWithoutADetector(t *testing.T) {
 	now := time.Now()
-	a := quietPiAgent("claude-agent", agentpkg.StateIdle, time.Hour, now)
-	a.Tool = "claude"
+	// Unregistered tool: DefaultRegistry has no FailureDetector for it.
+	// (claude/cursor/codex now implement DetectFailure — #3687.)
+	a := quietPiAgent("other-agent", agentpkg.StateIdle, time.Hour, now)
+	a.Tool = "unknown-tool"
 	deps := &fakeFailureDeps{
 		agents: []*agentpkg.Agent{a},
-		panes:  map[string]string{"claude-agent": brokenPiPane},
+		panes:  map[string]string{"other-agent": brokenPiPane},
 	}
 
 	sweepForFailedProviders(context.Background(), deps, map[string]string{}, now)


### PR DESCRIPTION
## Summary
- **#3686** — Connected-app vault secrets and well-known integration tokens are scoped to agents with unmuted notification subscriptions on the matching app instance / platform; role/template allowlists still always inject. Documented in apps + security docs.
- **#3687** — Add `FailureDetector` implementations for Claude, Cursor, and Codex (auth missing/invalid, credits/quota exhausted, model unavailable) using `LineStartsWith` markers so agent prose does not false-positive.

### Scoping model (#3686)
| Source | Injected when |
|---|---|
| Role / template `secrets` | Always |
| Connected-app Secret fields | Subscription instance prefix matches app instance (`slack:*` → `slack`, `telegram:alerts:ops` → `telegram:alerts`) |
| Well-known tokens (`SLACK_BOT_TOKEN`, …) | Any subscription on that platform (including labeled instances) |
| GitHub app → `GH_TOKEN` / `GITHUB_TOKEN` | Subscribed to that github instance, **or** role allowlist requested `GITHUB_TOKEN` / `GH_TOKEN` |

## Test plan
- [x] `go test ./pkg/agent/ ./pkg/provider/ -count=1`
- [ ] Spawn agent with Slack subscription only — confirm Telegram vault token absent from env
- [ ] Agent with no subscriptions — confirm connected-app secrets absent; role-declared secrets still present
- [ ] Claude/Cursor/Codex agents with fatal auth/quota panes flip to ERROR with a Live reason

Fixes #3686
Fixes #3687

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection and reporting for authentication, credit, access, and model-availability failures across Claude, Codex, and Cursor.
  - Vault credentials and integration tokens are now provided only when an agent has the relevant notification subscription or explicit access configuration.

- **Documentation**
  - Documented agent-specific vault credential scoping and subscription requirements.

- **Tests**
  - Added coverage for provider failure detection, subscription matching, explicit access rules, and healthy-session false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->