### PR TITLE
feat(web): channel compose/send and file upload in GatewayFeed

### DIFF
--- a/docs/reference/api-rest.md
+++ b/docs/reference/api-rest.md
@@ -415,7 +415,7 @@ Attachment upload/download (channel attachments and shared screenshots).
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/api/files/upload` | Multipart upload. Fields: `file` (required), `channel` (required), `sender` (optional, default `web`). Returns `201` with file metadata. Used by gateways/agents; the web UI currently downloads only. |
+| POST | `/api/files/upload` | Multipart upload. Fields: `file` (required), `channel` (required), `sender` (optional, default `web`). Returns `201` with file metadata. The web UI compose box inserts `[file:ID]` into the message. |
 | GET | `/api/files/{id}` | Download/serve a stored file (inline, cached for a day). |
 
 ---

--- a/web/src/api/__tests__/client.test.ts
+++ b/web/src/api/__tests__/client.test.ts
@@ -225,3 +225,35 @@ describe("api.createAgent", () => {
     });
   });
 });
+
+describe("api.sendChannel / api.uploadFile", () => {
+  it("POSTs channel + message + sender to /api/apps/channels/send", async () => {
+    fetchMock.mockReturnValue(jsonResponse({ sent: true }));
+    const res = await api.sendChannel("slack:general", "hello", "web");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/apps/channels/send");
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init.body as string)).toEqual({
+      channel: "slack:general",
+      message: "hello",
+      sender: "web",
+    });
+    expect(res.sent).toBe(true);
+  });
+
+  it("POSTs multipart FormData to /api/files/upload without a JSON Content-Type", async () => {
+    fetchMock.mockReturnValue(jsonResponse({ id: "abc123", filename: "note.txt" }, 201));
+    const file = new File(["hi"], "note.txt", { type: "text/plain" });
+    const meta = await api.uploadFile(file, "slack:general");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/files/upload");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBeUndefined();
+    const body = init.body as FormData;
+    expect(body.get("channel")).toBe("slack:general");
+    expect(body.get("sender")).toBe("web");
+    expect(meta.id).toBe("abc123");
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -29,9 +29,12 @@ function tap<T>(p: Promise<T>, keys: string[]): Promise<T> {
 }
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
+  // FormData must go out without a Content-Type so the browser (or undici)
+  // can set multipart/form-data with the boundary. JSON is the default.
+  const isForm = typeof FormData !== "undefined" && init?.body instanceof FormData;
+  const headers: Record<string, string> = isForm
+    ? {}
+    : { "Content-Type": "application/json" };
   const res = await fetch(`${BASE}${path}`, {
     ...init,
     headers: { ...headers, ...(init?.headers as Record<string, string> ?? {}) },
@@ -159,6 +162,18 @@ export interface ChannelMessage {
    *  platform resolved one (e.g. Slack users.info). Absent → initials. */
   avatar_url?: string;
   content: string;
+  created_at: string;
+}
+
+/** Metadata returned by POST /api/files/upload. MessageContent renders
+ *  the matching `[file:ID]` token as an inline image or download link. */
+export interface FileAttachment {
+  id: string;
+  filename: string;
+  mime_type: string;
+  size: number;
+  channel: string;
+  sender: string;
   created_at: string;
 }
 
@@ -1111,6 +1126,14 @@ export const api = {
       `/apps/channels/${encodeURIComponent(name)}/history?${params}`,
     );
   },
+  /** POST /api/apps/channels/send — deliver text (and `[file:ID]` refs)
+   *  through the gateway. `{sent:false}` means no outbound route, not an
+   *  HTTP error. Sender defaults to "web" to match file uploads. */
+  sendChannel: (channel: string, message: string, sender = "web") =>
+    request<{ sent: boolean }>("/apps/channels/send", {
+      method: "POST",
+      body: JSON.stringify({ channel, message, sender }),
+    }),
   // App-scoped subscription API — channels live under their app instance.
   listSubscriptions: () =>
     request<NotifySubscription[]>("/notify/subscriptions"),
@@ -1476,8 +1499,17 @@ export const api = {
   getAgentComputedStats: (name: string) =>
     request<ComputedStats>(`/agents/${encodeURIComponent(name)}/stats-computed`),
 
-  /** Get file download URL. Uploads go through POST /api/files/upload
-   *  directly (gateway/agents); the web UI has no upload affordance yet. */
+  /** Multipart upload. Returns metadata whose `id` is inserted into a
+   *  channel message as `[file:ID]` (see MessageContent). */
+  uploadFile: (file: File, channel: string, sender = "web") => {
+    const body = new FormData();
+    body.append("file", file);
+    body.append("channel", channel);
+    body.append("sender", sender);
+    return request<FileAttachment>("/files/upload", { method: "POST", body });
+  },
+
+  /** Get file download URL for a stored attachment id. */
   getFileUrl: (id: string) => `${BASE}/files/${encodeURIComponent(id)}`,
 
   /** Full machine-readiness report — tmux, git, provider CLIs, docker images. */

--- a/web/src/components/apps/ChannelCompose.tsx
+++ b/web/src/components/apps/ChannelCompose.tsx
@@ -1,0 +1,278 @@
+import { useCallback, useRef, useState } from "react";
+import { api } from "../../api/client";
+
+/** Matches pkg/attachment.MaxFilesPerMessage. */
+export const MAX_FILES_PER_MESSAGE = 5;
+
+const FILE_REF_RE = /\[file:[a-zA-Z0-9_-]+\]/g;
+
+export function fileRef(id: string): string {
+  return `[file:${id}]`;
+}
+
+function fileRefCount(text: string): number {
+  return text.match(FILE_REF_RE)?.length ?? 0;
+}
+
+function appendFileRef(draft: string, id: string): string {
+  const ref = fileRef(id);
+  const trimmed = draft.replace(/\s+$/, "");
+  return trimmed ? `${trimmed} ${ref}` : ref;
+}
+
+type Status = { kind: "error" | "warn" | "info"; text: string } | null;
+
+export function ChannelCompose({
+  channelName,
+  onSent,
+}: {
+  channelName: string;
+  onSent?: () => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [dragOver, setDragOver] = useState(false);
+  const [status, setStatus] = useState<Status>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const dragDepth = useRef(0);
+
+  const channelLabel = channelName.includes(":")
+    ? (channelName.split(":").pop() || channelName)
+    : channelName;
+
+  const busy = sending || uploading;
+  const canSend = draft.trim().length > 0 && !busy;
+
+  const uploadFiles = useCallback(
+    async (files: FileList | File[]) => {
+      const list = Array.from(files).filter((f) => f.size > 0);
+      if (list.length === 0) return;
+
+      const room = MAX_FILES_PER_MESSAGE - fileRefCount(draft);
+      if (room <= 0) {
+        setStatus({ kind: "warn", text: `Up to ${MAX_FILES_PER_MESSAGE} files per message` });
+        return;
+      }
+      const batch = list.slice(0, room);
+      if (list.length > room) {
+        setStatus({ kind: "warn", text: `Up to ${MAX_FILES_PER_MESSAGE} files per message` });
+      } else {
+        setStatus(null);
+      }
+
+      setUploading(true);
+      try {
+        let next = draft;
+        for (const file of batch) {
+          const meta = await api.uploadFile(file, channelName);
+          next = appendFileRef(next, meta.id);
+          setDraft(next);
+        }
+      } catch (e) {
+        setStatus({
+          kind: "error",
+          text: e instanceof Error ? e.message : "Upload failed",
+        });
+      } finally {
+        setUploading(false);
+        textareaRef.current?.focus();
+      }
+    },
+    [channelName, draft],
+  );
+
+  const handleSend = useCallback(async () => {
+    const text = draft.trim();
+    if (!text || busy) return;
+    setSending(true);
+    setStatus(null);
+    try {
+      const { sent } = await api.sendChannel(channelName, text);
+      if (!sent) {
+        setStatus({ kind: "warn", text: "No outbound route for this channel" });
+        return;
+      }
+      setDraft("");
+      onSent?.();
+    } catch (e) {
+      setStatus({
+        kind: "error",
+        text: e instanceof Error ? e.message : "Send failed",
+      });
+    } finally {
+      setSending(false);
+      textareaRef.current?.focus();
+    }
+  }, [busy, channelName, draft, onSent]);
+
+  const onDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    dragDepth.current = 0;
+    setDragOver(false);
+    if (e.dataTransfer.files?.length) {
+      void uploadFiles(e.dataTransfer.files);
+    }
+  };
+
+  return (
+    <div
+      data-testid="channel-compose"
+      className="shrink-0"
+      style={{
+        padding: "8px 16px 12px",
+        borderTop: "1px solid var(--mycel-border)",
+        background: "var(--mycel-surface)",
+      }}
+      onDragEnter={(e) => {
+        e.preventDefault();
+        dragDepth.current += 1;
+        setDragOver(true);
+      }}
+      onDragLeave={(e) => {
+        e.preventDefault();
+        dragDepth.current = Math.max(0, dragDepth.current - 1);
+        if (dragDepth.current === 0) setDragOver(false);
+      }}
+      onDragOver={(e) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "copy";
+      }}
+      onDrop={onDrop}
+    >
+      {status && (
+        <div
+          role="status"
+          style={{
+            fontSize: 11,
+            marginBottom: 6,
+            color:
+              status.kind === "error"
+                ? "var(--mycel-error)"
+                : status.kind === "warn"
+                  ? "var(--mycel-warning)"
+                  : "var(--mycel-muted)",
+          }}
+        >
+          {status.text}
+        </div>
+      )}
+      <div
+        className="flex items-end"
+        style={{
+          gap: 6,
+          padding: "4px 6px 4px 4px",
+          borderRadius: 8,
+          border: dragOver
+            ? "1px dashed var(--mycel-accent)"
+            : "1px solid var(--mycel-border)",
+          background: "var(--mycel-bg)",
+        }}
+      >
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          data-testid="channel-file-input"
+          className="sr-only"
+          tabIndex={-1}
+          onChange={(e) => {
+            const files = e.currentTarget.files;
+            e.currentTarget.value = "";
+            if (files?.length) void uploadFiles(files);
+          }}
+        />
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={busy}
+          aria-label="Attach file"
+          title="Attach file"
+          className="relative flex items-center justify-center outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent before:absolute before:-inset-1 before:content-['']"
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: 6,
+            color: "var(--mycel-muted)",
+            background: "none",
+            border: "none",
+            cursor: busy ? "wait" : "pointer",
+            flexShrink: 0,
+          }}
+        >
+          {uploading ? (
+            <span
+              className="inline-block w-3 h-3 border border-current border-t-transparent rounded-full animate-spin"
+              aria-hidden
+            />
+          ) : (
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48" />
+            </svg>
+          )}
+        </button>
+        <textarea
+          ref={textareaRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+              e.preventDefault();
+              void handleSend();
+            }
+          }}
+          rows={1}
+          disabled={sending}
+          placeholder={dragOver ? "Drop to attach" : `Message #${channelLabel}`}
+          aria-label="Message"
+          style={{
+            flex: 1,
+            minHeight: 28,
+            maxHeight: 120,
+            resize: "none",
+            background: "none",
+            border: "none",
+            outline: "none",
+            color: "var(--mycel-text)",
+            fontSize: 13,
+            lineHeight: "20px",
+            padding: "4px 0",
+            fontFamily: "inherit",
+          }}
+        />
+        <button
+          type="button"
+          onClick={() => void handleSend()}
+          disabled={!canSend}
+          aria-label="Send"
+          title="Send"
+          className="relative flex items-center justify-center outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent before:absolute before:-inset-1 before:content-['']"
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: 6,
+            color: canSend ? "var(--mycel-accent)" : "var(--mycel-muted)",
+            background: "none",
+            border: "none",
+            cursor: canSend ? "pointer" : "default",
+            flexShrink: 0,
+            opacity: canSend ? 1 : 0.5,
+          }}
+        >
+          {sending ? (
+            <span
+              className="inline-block w-3 h-3 border border-current border-t-transparent rounded-full animate-spin"
+              aria-hidden
+            />
+          ) : (
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <line x1="22" y1="2" x2="11" y2="13" />
+              <polygon points="22 2 15 22 11 13 2 9 22 2" />
+            </svg>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/apps/GatewayFeed.tsx
+++ b/web/src/components/apps/GatewayFeed.tsx
@@ -24,6 +24,7 @@ import {
 } from "./messageUtils";
 import { AgentCharacter, LiveAgentCharacter } from "../agent-ui";
 import { IdentityAvatar } from "./IdentityAvatar";
+import { ChannelCompose } from "./ChannelCompose";
 import type { GitHubCard, RSSCard, WebhookCard } from "./messageUtils";
 
 /* ── Helpers ──────────────────────────────────────────────────── */
@@ -1490,6 +1491,23 @@ export function GatewayFeed({
           </div>
         </div>
       </div>
+
+      <ChannelCompose
+        channelName={channelName}
+        onSent={() => {
+          void api
+            .getChannelHistory(channelName, PAGE_SIZE)
+            .then((latest) => {
+              if (!latest?.length) return;
+              setMessages((prev) => {
+                const ids = new Set(prev.map((m) => m.id));
+                const incoming = latest.filter((m) => m.id && !ids.has(m.id));
+                return incoming.length === 0 ? prev : [...prev, ...incoming];
+              });
+            })
+            .catch(() => {});
+        }}
+      />
 
       <style>{`@keyframes fadeIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }`}</style>
     </div>

--- a/web/src/components/apps/__tests__/channelCompose.test.tsx
+++ b/web/src/components/apps/__tests__/channelCompose.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * ChannelCompose — send text and attach files on a gateway channel.
+ * MessageContent renders `[file:ID]` tokens; this control is how they
+ * get into the draft (paperclip / drag-drop → POST /api/files/upload).
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ChannelCompose, fileRef } from "../ChannelCompose";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 201 ? "Created" : "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("ChannelCompose", () => {
+  it("POSTs typed text to /api/apps/channels/send and clears the draft", async () => {
+    fetchMock.mockReturnValue(jsonResponse({ sent: true }));
+    const onSent = vi.fn();
+    render(<ChannelCompose channelName="slack:general" onSent={onSent} />);
+
+    fireEvent.change(screen.getByLabelText("Message"), { target: { value: "hello channel" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/apps/channels/send",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      channel: "slack:general",
+      message: "hello channel",
+      sender: "web",
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Message")).toHaveValue("");
+    });
+    expect(onSent).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends on Enter and keeps the draft on Shift+Enter", async () => {
+    fetchMock.mockReturnValue(jsonResponse({ sent: true }));
+    render(<ChannelCompose channelName="telegram:alerts" />);
+
+    const box = screen.getByLabelText("Message");
+    fireEvent.change(box, { target: { value: "line one" } });
+    fireEvent.keyDown(box, { key: "Enter", shiftKey: true });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(box).toHaveValue("line one");
+
+    fireEvent.keyDown(box, { key: "Enter", shiftKey: false });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps the draft and surfaces a warning when the channel has no route", async () => {
+    fetchMock.mockReturnValue(jsonResponse({ sent: false }));
+    render(<ChannelCompose channelName="engineering" />);
+
+    fireEvent.change(screen.getByLabelText("Message"), { target: { value: "ping" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent("No outbound route");
+    expect(screen.getByLabelText("Message")).toHaveValue("ping");
+  });
+
+  it("uploads a paperclip file and inserts [file:ID] into the draft", async () => {
+    fetchMock.mockReturnValue(
+      jsonResponse(
+        { id: "abc123", filename: "note.txt", mime_type: "text/plain", size: 4, channel: "slack:general", sender: "web", created_at: "2026-01-01T00:00:00Z" },
+        201,
+      ),
+    );
+    render(<ChannelCompose channelName="slack:general" />);
+
+    const file = new File(["hi\n"], "note.txt", { type: "text/plain" });
+    fireEvent.change(screen.getByTestId("channel-file-input"), {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Message")).toHaveValue(fileRef("abc123"));
+    });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/files/upload");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(FormData);
+    const body = init.body as FormData;
+    expect(body.get("channel")).toBe("slack:general");
+    expect(body.get("sender")).toBe("web");
+    expect(body.get("file")).toBeInstanceOf(File);
+  });
+
+  it("uploads a dropped file the same way as the paperclip", async () => {
+    fetchMock.mockReturnValue(
+      jsonResponse(
+        { id: "drop1", filename: "shot.png", mime_type: "image/png", size: 8, channel: "slack:general", sender: "web", created_at: "2026-01-01T00:00:00Z" },
+        201,
+      ),
+    );
+    render(<ChannelCompose channelName="slack:general" />);
+
+    const file = new File(["pngdata"], "shot.png", { type: "image/png" });
+    fireEvent.drop(screen.getByTestId("channel-compose"), {
+      dataTransfer: { files: [file], types: ["Files"] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Message")).toHaveValue(fileRef("drop1"));
+    });
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/files/upload");
+  });
+});

--- a/web/src/components/apps/__tests__/gatewayFeedBack.test.tsx
+++ b/web/src/components/apps/__tests__/gatewayFeedBack.test.tsx
@@ -67,4 +67,25 @@ describe("GatewayFeed", () => {
     await screen.findByTestId("header-host");
     expect(screen.queryByRole("button", { name: "Go back" })).not.toBeInTheDocument();
   });
+
+  it("renders a compose box so the channel view is not read-only", async () => {
+    render(
+      <MemoryRouter initialEntries={["/apps/slack:general"]}>
+        <HeaderSlotProvider>
+          <HeaderHost />
+          <Routes>
+            <Route
+              path="/apps/:sourceName"
+              element={<GatewayFeed channelName="slack:general" onPeekAgent={() => {}} />}
+            />
+          </Routes>
+        </HeaderSlotProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByTestId("channel-compose")).toBeInTheDocument();
+    expect(screen.getByLabelText("Message")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Attach file" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
Channel views were read-only even though `POST /api/apps/channels/send` and `POST /api/files/upload` already existed. This adds a compose bar on GatewayFeed so you can send text and attach files.

Fixes #3689
Fixes #3654

## Changes
- `api.sendChannel` / `api.uploadFile` client wrappers (`FormData` skips the JSON Content-Type)
- `ChannelCompose` on the channel feed: Enter to send, paperclip + drag-drop upload inserts `[file:ID]` (the token MessageContent already renders)
- Vitest for the client helpers, compose control, and feed wiring

## Test Plan
- [ ] `cd web && npm test -- --run src/api/__tests__/client.test.ts src/components/apps/__tests__/channelCompose.test.tsx src/components/apps/__tests__/gatewayFeedBack.test.tsx` (27 passed locally)
- [x] New/updated tests cover the change
- [ ] Manual: open a gateway channel, send text, attach via paperclip, drag-drop a file, confirm `[file:ID]` renders in the feed
- [ ] Manual: a channel with no outbound route keeps the draft and shows a warning

## Checklist
- [x] PR title follows conventional commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] No secrets or credentials in the diff
- [x] Documentation updated (if applicable)