### PR TITLE
feat(web): GitHub repo discover + clone in Create Agent

### DIFF
--- a/web/src/api/__tests__/client.test.ts
+++ b/web/src/api/__tests__/client.test.ts
@@ -257,3 +257,70 @@ describe("api.sendChannel / api.uploadFile", () => {
     expect(meta.id).toBe("abc123");
   });
 });
+
+describe("api GitHub discover + clone", () => {
+  it("getGithubAuth hits GET /api/auth/github", async () => {
+    fetchMock.mockReturnValue(jsonResponse({ connected: true, login: "puneet" }));
+    const status = await api.getGithubAuth();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/auth/github");
+    expect(init?.method ?? "GET").not.toBe("POST");
+    expect(status.connected).toBe(true);
+    expect(status.login).toBe("puneet");
+  });
+
+  it("setGithubToken POSTs the token", async () => {
+    fetchMock.mockReturnValue(jsonResponse({ connected: true, login: "puneet" }));
+    await api.setGithubToken("ghp_test");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/auth/github");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ token: "ghp_test" });
+  });
+
+  it("deleteGithubToken accepts 204 with no body", async () => {
+    fetchMock.mockReturnValue(
+      Promise.resolve({
+        ok: true,
+        status: 204,
+        statusText: "No Content",
+        json: () => Promise.reject(new Error("no body")),
+      } as unknown as Response),
+    );
+    await expect(api.deleteGithubToken()).resolves.toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/auth/github");
+    expect(init.method).toBe("DELETE");
+  });
+
+  it("discoverGithubRepos POSTs an optional query", async () => {
+    fetchMock.mockReturnValue(jsonResponse({ repos: [{ full_name: "acme/mycel", name: "mycel" }] }));
+    const empty = await api.discoverGithubRepos();
+    expect(empty.repos[0]?.name).toBe("mycel");
+    expect(JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string)).toEqual({});
+
+    await api.discoverGithubRepos("mycel");
+    const [url, init] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(url).toBe("/api/repos/discover/github");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ query: "mycel" });
+  });
+
+  it("cloneRepo POSTs url, target, and optional name", async () => {
+    fetchMock.mockReturnValue(jsonResponse({ path: "/tmp/src/mycel", name: "mycel" }, 201));
+    const result = await api.cloneRepo({
+      url: "https://github.com/acme/mycel.git",
+      target: "/tmp/src",
+      name: "mycel",
+    });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/repos/clone");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      url: "https://github.com/acme/mycel.git",
+      target: "/tmp/src",
+      name: "mycel",
+    });
+    expect(result.path).toBe("/tmp/src/mycel");
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -67,6 +67,30 @@ export interface ReposResponse {
   default: string;
 }
 
+/** GET/POST /api/auth/github — token presence, plus login after a successful POST. */
+export interface GithubAuthStatus {
+  connected: boolean;
+  login?: string;
+}
+
+/** One repository from POST /api/repos/discover/github. */
+export interface GithubRepo {
+  full_name: string;
+  name: string;
+  clone_url: string;
+  ssh_url: string;
+  html_url: string;
+  default_branch: string;
+  description?: string;
+  private: boolean;
+}
+
+/** POST /api/repos/clone — checkout path the new agent should bind to. */
+export interface CloneRepoResult {
+  path: string;
+  name: string;
+}
+
 export interface BulkResult {
   agent: string;
   status: "ok" | "error";
@@ -1474,6 +1498,41 @@ export const api = {
   /** List repos known to the daemon (every repo referenced by an agent
    *  plus the boot repo) and the default repo for new agents. */
   getRepos: () => request<ReposResponse>("/repos"),
+
+  /** GitHub PAT status for repo discover/clone. GET does not echo the token. */
+  getGithubAuth: () => request<GithubAuthStatus>("/auth/github"),
+  /** Validate and store a GitHub PAT in ~/.mycel/github-token. */
+  setGithubToken: (token: string) =>
+    request<GithubAuthStatus>("/auth/github", {
+      method: "POST",
+      body: JSON.stringify({ token }),
+    }),
+  /** Remove the stored GitHub PAT. 204 has no body. */
+  deleteGithubToken: async (): Promise<void> => {
+    const res = await fetch(`${BASE}/auth/github`, { method: "DELETE" });
+    if (res.status === 204 || res.ok) return;
+    let message = `API error: ${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body && typeof body.error === "string") message = body.error;
+    } catch {
+      /* empty */
+    }
+    throw new Error(message);
+  },
+  /** List GitHub repos visible to the stored PAT. 401 when not authenticated. */
+  discoverGithubRepos: (query?: string) =>
+    request<{ repos: GithubRepo[] }>("/repos/discover/github", {
+      method: "POST",
+      body: JSON.stringify(query ? { query } : {}),
+    }),
+  /** Clone a URL into target (optional checkout name). Not registered until
+   *  an agent is created with the returned path. */
+  cloneRepo: (opts: { url: string; target: string; name?: string }) =>
+    request<CloneRepoResult>("/repos/clone", {
+      method: "POST",
+      body: JSON.stringify(opts),
+    }),
 
   getStatsSystem: () => request<SystemStats>("/stats/system"),
   getStatsSummary: () => request<StatsSummary>("/stats/summary"),

--- a/web/src/components/CreateAgentModal.tsx
+++ b/web/src/components/CreateAgentModal.tsx
@@ -6,6 +6,7 @@ import { EnvVarsEditor, isValidEnvKey } from "./EnvVarsEditor";
 import type { EnvRow } from "./EnvVarsEditor";
 import { AgentAppsPicker } from "./apps/AgentAppsPicker";
 import { api } from "../api/client";
+import type { GithubRepo } from "../api/client";
 import { MONO } from "../utils/typography";
 import { pickDirectory } from "../utils/pickDirectory";
 import { useReadiness } from "../hooks/useReadiness";
@@ -78,6 +79,13 @@ interface RepoCandidate {
   name: string;
 }
 
+function parentDir(path: string): string {
+  const trimmed = path.replace(/\/+$/, "");
+  const i = trimmed.lastIndexOf("/");
+  if (i <= 0) return "/";
+  return trimmed.slice(0, i);
+}
+
 type Provider = "claude" | "agy" | "cursor" | "codex" | "pi";
 type Runtime = "docker" | "tmux";
 
@@ -131,6 +139,21 @@ export function CreateAgentModal({
   const [candidates, setCandidates] = useState<RepoCandidate[] | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  // GitHub: connect a PAT (or reuse ~/.mycel/github-token), list/filter
+  // repos, clone into a target path, then bind the agent to that path —
+  // same end state as picking a local candidate.
+  const [githubOpen, setGithubOpen] = useState(false);
+  const [githubConnected, setGithubConnected] = useState(false);
+  const [githubLogin, setGithubLogin] = useState("");
+  const [githubToken, setGithubToken] = useState("");
+  const [githubConnecting, setGithubConnecting] = useState(false);
+  const [githubListing, setGithubListing] = useState(false);
+  const [githubRepos, setGithubRepos] = useState<GithubRepo[] | null>(null);
+  const [githubQuery, setGithubQuery] = useState("");
+  const [githubSelected, setGithubSelected] = useState<GithubRepo | null>(null);
+  const [githubError, setGithubError] = useState<string | null>(null);
+  const [cloneTarget, setCloneTarget] = useState("");
+  const [cloning, setCloning] = useState(false);
 
   // Machine readiness for the selected provider/runtime — probed only
   // while the modal is open. Powers a non-blocking pre-flight warning so
@@ -246,6 +269,18 @@ export function CreateAgentModal({
       setBrowseOpen(false);
       setCandidates(null);
       setScanError(null);
+      setGithubOpen(false);
+      setGithubConnected(false);
+      setGithubLogin("");
+      setGithubToken("");
+      setGithubConnecting(false);
+      setGithubListing(false);
+      setGithubRepos(null);
+      setGithubQuery("");
+      setGithubSelected(null);
+      setGithubError(null);
+      setCloneTarget("");
+      setCloning(false);
       requestAnimationFrame(() => firstInputRef.current?.focus());
     }
     prevOpenRef.current = open;
@@ -315,6 +350,7 @@ export function CreateAgentModal({
   // typed-path panel when the dialog is unavailable (plain browser, cancel).
   const handleChooseFolder = useCallback(async () => {
     setBrowseOpen(true);
+    setGithubOpen(false);
     const picked = await pickDirectory();
     if (!picked) {
       if (!browseRoot && repo) {
@@ -330,6 +366,132 @@ export function CreateAgentModal({
     }
     await handleScan(picked);
   }, [browseRoot, repo, handleScan]);
+
+  const loadGithubRepos = useCallback(async (query = "") => {
+    setGithubListing(true);
+    setGithubError(null);
+    try {
+      const data = await api.discoverGithubRepos(query);
+      setGithubRepos(Array.isArray(data.repos) ? data.repos : []);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to list GitHub repos";
+      setGithubError(msg);
+      if (/not authenticated/i.test(msg)) {
+        setGithubConnected(false);
+        setGithubLogin("");
+        setGithubRepos(null);
+      }
+    } finally {
+      setGithubListing(false);
+    }
+  }, []);
+
+  // When the GitHub panel opens, reuse a stored PAT if present and list
+  // repos. Clone target defaults to the projects scan root (or the parent
+  // of the current/default repo) so the user isn't starting from blank.
+  useEffect(() => {
+    if (!open || !githubOpen) return;
+    let cancelled = false;
+    setCloneTarget((prev) => {
+      if (prev) return prev;
+      if (browseRoot.trim()) return browseRoot.trim();
+      if (repo.trim()) return parentDir(repo.trim());
+      if (defaultRepo.trim()) return parentDir(defaultRepo.trim());
+      return prev;
+    });
+    (async () => {
+      setGithubError(null);
+      try {
+        const status = await api.getGithubAuth();
+        if (cancelled) return;
+        setGithubConnected(!!status.connected);
+        setGithubLogin(typeof status.login === "string" ? status.login : "");
+        if (status.connected) await loadGithubRepos();
+      } catch (e) {
+        if (!cancelled) {
+          setGithubError(e instanceof Error ? e.message : "Failed to check GitHub auth");
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+    // browseRoot/repo/defaultRepo snapshot the clone-target default when the
+    // panel opens; listing them would re-fetch GitHub on every keystroke.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, githubOpen, loadGithubRepos]);
+
+  const handleConnectGithub = useCallback(async () => {
+    const token = githubToken.trim();
+    if (!token) {
+      setGithubError("Paste a GitHub personal access token.");
+      return;
+    }
+    setGithubConnecting(true);
+    setGithubError(null);
+    try {
+      const status = await api.setGithubToken(token);
+      setGithubConnected(true);
+      setGithubLogin(typeof status.login === "string" ? status.login : "");
+      setGithubToken("");
+      await loadGithubRepos();
+    } catch (e) {
+      setGithubError(e instanceof Error ? e.message : "Failed to connect GitHub");
+    } finally {
+      setGithubConnecting(false);
+    }
+  }, [githubToken, loadGithubRepos]);
+
+  const handleDisconnectGithub = useCallback(async () => {
+    setGithubError(null);
+    try {
+      await api.deleteGithubToken();
+      setGithubConnected(false);
+      setGithubLogin("");
+      setGithubRepos(null);
+      setGithubSelected(null);
+      setGithubQuery("");
+    } catch (e) {
+      setGithubError(e instanceof Error ? e.message : "Failed to disconnect GitHub");
+    }
+  }, []);
+
+  const handleChooseCloneTarget = useCallback(async () => {
+    const picked = await pickDirectory();
+    if (!picked) return;
+    setCloneTarget(picked);
+    try {
+      localStorage.setItem("mycel.projects_scan_root", picked);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const handleCloneGithub = useCallback(async () => {
+    if (!githubSelected) {
+      setGithubError("Select a repository to clone.");
+      return;
+    }
+    const target = cloneTarget.trim();
+    if (!target) {
+      setGithubError("Enter a directory to clone into, or use Choose…");
+      return;
+    }
+    setCloning(true);
+    setGithubError(null);
+    try {
+      const result = await api.cloneRepo({
+        url: githubSelected.clone_url,
+        target,
+        name: githubSelected.name,
+      });
+      setRepo(result.path);
+      setGithubOpen(false);
+      setGithubSelected(null);
+    } catch (e) {
+      setGithubError(e instanceof Error ? e.message : "Clone failed");
+    } finally {
+      setCloning(false);
+    }
+  }, [githubSelected, cloneTarget]);
 
   const handleCreate = useCallback(async () => {
     const trimmed = name.trim();
@@ -455,6 +617,13 @@ export function CreateAgentModal({
   const canCreate =
     groupComplete.repo && groupComplete.identity && groupComplete.tool && template.trim() !== "";
 
+  const githubFilter = githubQuery.trim().toLowerCase();
+  const visibleGithubRepos = (githubRepos ?? []).filter((r) =>
+    !githubFilter
+    || r.full_name.toLowerCase().includes(githubFilter)
+    || r.name.toLowerCase().includes(githubFilter),
+  );
+
   if (!open) return null;
 
   return (
@@ -525,6 +694,24 @@ export function CreateAgentModal({
                   }`}
                 >
                   Browse
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setGithubOpen((prev) => {
+                      const next = !prev;
+                      if (next) setBrowseOpen(false);
+                      return next;
+                    });
+                  }}
+                  aria-pressed={githubOpen}
+                  className={`shrink-0 inline-flex items-center px-3 h-8 rounded-md border text-xs font-medium transition-colors ${
+                    githubOpen
+                      ? "border-mycel-accent text-mycel-accent bg-mycel-bg"
+                      : "border-mycel-border bg-mycel-bg text-mycel-muted hover:text-mycel-accent hover:border-mycel-accent"
+                  }`}
+                >
+                  GitHub
                 </button>
               </div>
               {knownRepos.length > 0 && (
@@ -612,6 +799,156 @@ export function CreateAgentModal({
                         </li>
                       ))}
                     </ul>
+                  )}
+                </div>
+              )}
+              {githubOpen && (
+                <div
+                  data-testid="create-agent-github-panel"
+                  className="flex flex-col gap-2 rounded-md border border-mycel-border bg-mycel-bg p-2"
+                >
+                  {githubConnected ? (
+                    <>
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-xs text-mycel-muted truncate">
+                          {githubLogin ? `Connected as ${githubLogin}` : "GitHub connected"}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => { void handleDisconnectGithub(); }}
+                          className="shrink-0 text-[11px] text-mycel-muted hover:text-mycel-accent transition-colors"
+                        >
+                          Disconnect
+                        </button>
+                      </div>
+                      <input
+                        type="text"
+                        value={githubQuery}
+                        onChange={(e) => setGithubQuery(e.target.value)}
+                        className={INPUT_CLS}
+                        style={{ fontFamily: MONO }}
+                        placeholder="filter repos"
+                        aria-label="Filter GitHub repos"
+                        spellCheck={false}
+                        autoComplete="off"
+                      />
+                      {githubListing && (
+                        <div className="text-xs text-mycel-muted">Loading...</div>
+                      )}
+                      {!githubListing && githubRepos && githubRepos.length === 0 && (
+                        <div className="text-xs text-mycel-muted">
+                          No GitHub repos found.
+                        </div>
+                      )}
+                      {!githubListing && githubRepos && githubRepos.length > 0 && visibleGithubRepos.length === 0 && (
+                        <div className="text-xs text-mycel-muted">
+                          No repos match that filter.
+                        </div>
+                      )}
+                      {!githubListing && visibleGithubRepos.length > 0 && (
+                        <ul className="max-h-36 overflow-y-auto flex flex-col">
+                          {visibleGithubRepos.map((r) => {
+                            const selected = githubSelected?.full_name === r.full_name;
+                            return (
+                              <li key={r.full_name}>
+                                <button
+                                  type="button"
+                                  onClick={() => setGithubSelected(r)}
+                                  aria-pressed={selected}
+                                  className={`w-full text-left px-2 py-1 rounded-md text-xs transition-colors truncate ${
+                                    selected
+                                      ? "bg-mycel-surface text-mycel-accent"
+                                      : "text-mycel-text hover:bg-mycel-surface hover:text-mycel-accent"
+                                  }`}
+                                  style={{ fontFamily: MONO }}
+                                  title={r.full_name}
+                                >
+                                  {r.name}{" "}
+                                  <span className="text-mycel-muted">{r.full_name}</span>
+                                  {r.private ? (
+                                    <span className="text-mycel-muted"> · private</span>
+                                  ) : null}
+                                </button>
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      )}
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="text"
+                          value={cloneTarget}
+                          onChange={(e) => setCloneTarget(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                              e.preventDefault();
+                              void handleCloneGithub();
+                            }
+                          }}
+                          className={INPUT_CLS}
+                          style={{ fontFamily: MONO }}
+                          placeholder="/directory/to/clone into"
+                          aria-label="Clone target directory"
+                          spellCheck={false}
+                          autoComplete="off"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => { void handleChooseCloneTarget(); }}
+                          disabled={cloning}
+                          className="shrink-0 inline-flex items-center px-3 h-8 rounded-md border border-mycel-border bg-mycel-surface text-xs font-medium text-mycel-muted hover:text-mycel-accent hover:border-mycel-accent transition-colors disabled:opacity-50"
+                          title="Open native folder picker"
+                        >
+                          Choose…
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => { void handleCloneGithub(); }}
+                          disabled={cloning || !githubSelected}
+                          className="shrink-0 inline-flex items-center px-3 h-8 rounded-md border border-mycel-border bg-mycel-surface text-xs font-medium text-mycel-muted hover:text-mycel-accent hover:border-mycel-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          {cloning ? "Cloning..." : "Clone"}
+                        </button>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <p className="text-[11px] text-mycel-muted">
+                        Paste a personal access token with repo scope to list and clone repositories.
+                      </p>
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="password"
+                          value={githubToken}
+                          onChange={(e) => setGithubToken(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                              e.preventDefault();
+                              void handleConnectGithub();
+                            }
+                          }}
+                          className={INPUT_CLS}
+                          style={{ fontFamily: MONO }}
+                          placeholder="ghp_… or github_pat_…"
+                          aria-label="GitHub token"
+                          spellCheck={false}
+                          autoComplete="off"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => { void handleConnectGithub(); }}
+                          disabled={githubConnecting}
+                          className="shrink-0 inline-flex items-center px-3 h-8 rounded-md border border-mycel-border bg-mycel-surface text-xs font-medium text-mycel-muted hover:text-mycel-accent hover:border-mycel-accent transition-colors disabled:opacity-50"
+                        >
+                          {githubConnecting ? "Connecting..." : "Connect"}
+                        </button>
+                      </div>
+                    </>
+                  )}
+                  {githubError && (
+                    <div className="text-xs text-mycel-error">
+                      {githubError}
+                    </div>
                   )}
                 </div>
               )}

--- a/web/src/components/__tests__/CreateAgentModalGithub.test.tsx
+++ b/web/src/components/__tests__/CreateAgentModalGithub.test.tsx
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { CreateAgentModal } from "../CreateAgentModal";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+const GH_REPOS = [
+  {
+    full_name: "acme/mycel",
+    name: "mycel",
+    clone_url: "https://github.com/acme/mycel.git",
+    ssh_url: "git@github.com:acme/mycel.git",
+    html_url: "https://github.com/acme/mycel",
+    default_branch: "main",
+    private: false,
+  },
+  {
+    full_name: "acme/private-notes",
+    name: "private-notes",
+    clone_url: "https://github.com/acme/private-notes.git",
+    ssh_url: "git@github.com:acme/private-notes.git",
+    html_url: "https://github.com/acme/private-notes",
+    default_branch: "main",
+    private: true,
+  },
+];
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+function errorResponse(message: string, status: number) {
+  return Promise.resolve({
+    ok: false,
+    status,
+    statusText: status === 401 ? "Unauthorized" : "Error",
+    json: () => Promise.resolve({ error: message }),
+  } as Response);
+}
+
+function mockApi(opts: {
+  connected?: boolean;
+  login?: string;
+  repos?: typeof GH_REPOS;
+  clonePath?: string;
+} = {}) {
+  const connected = opts.connected ?? false;
+  const login = opts.login ?? "puneet";
+  const repos = opts.repos ?? GH_REPOS;
+  const clonePath = opts.clonePath ?? "/tmp/src/mycel";
+
+  fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+    const u = String(url);
+    const method = init?.method ?? "GET";
+    if (u === "/api/auth/github" && method === "GET") {
+      return jsonResponse({ connected, login: connected ? login : undefined });
+    }
+    if (u === "/api/auth/github" && method === "POST") {
+      return jsonResponse({ connected: true, login });
+    }
+    if (u === "/api/auth/github" && method === "DELETE") {
+      return Promise.resolve({
+        ok: true,
+        status: 204,
+        json: () => Promise.reject(new Error("no body")),
+      } as unknown as Response);
+    }
+    if (u === "/api/repos/discover/github") {
+      if (!connected && method === "POST") {
+        // After a successful Connect POST, subsequent list calls should succeed.
+        const connectPosted = fetchMock.mock.calls.some(
+          (c) => String(c[0]) === "/api/auth/github" && (c[1] as RequestInit | undefined)?.method === "POST",
+        );
+        if (!connectPosted) return errorResponse("github not authenticated", 401);
+      }
+      return jsonResponse({ repos });
+    }
+    if (u === "/api/repos/clone") {
+      return jsonResponse({ path: clonePath, name: "mycel" }, 201);
+    }
+    if (u === "/api/agents" && method === "POST") {
+      return jsonResponse({ name: "bold-otter" });
+    }
+    if (u.includes("/api/repos")) return jsonResponse({ repos: [], default: "/tmp/repo" });
+    return jsonResponse([]);
+  });
+}
+
+function renderModal() {
+  return render(
+    <MemoryRouter>
+      <CreateAgentModal open onClose={() => undefined} existingNames={[]} />
+    </MemoryRouter>,
+  );
+}
+
+async function openGithubPanel() {
+  fireEvent.click(screen.getByRole("button", { name: "GitHub" }));
+  return waitFor(() => {
+    expect(screen.getByTestId("create-agent-github-panel")).toBeInTheDocument();
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  mockApi();
+});
+
+describe("CreateAgentModal GitHub discover", () => {
+  it("shows a GitHub button next to Browse", () => {
+    renderModal();
+    expect(screen.getByRole("button", { name: "GitHub" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Browse" })).toBeInTheDocument();
+  });
+
+  it("asks for a token when GitHub is not connected", async () => {
+    renderModal();
+    await openGithubPanel();
+    const panel = screen.getByTestId("create-agent-github-panel");
+    expect(within(panel).getByLabelText("GitHub token")).toBeInTheDocument();
+    expect(within(panel).getByRole("button", { name: "Connect" })).toBeInTheDocument();
+    expect(within(panel).queryByRole("button", { name: "Clone" })).not.toBeInTheDocument();
+  });
+
+  it("connects a token, lists repos, clones, and binds the path", async () => {
+    renderModal();
+    await openGithubPanel();
+    const panel = screen.getByTestId("create-agent-github-panel");
+    fireEvent.change(within(panel).getByLabelText("GitHub token"), {
+      target: { value: "ghp_testtoken" },
+    });
+    fireEvent.click(within(panel).getByRole("button", { name: "Connect" }));
+
+    await waitFor(() => {
+      expect(within(panel).getByText("acme/mycel")).toBeInTheDocument();
+    });
+    const connect = fetchMock.mock.calls.find(
+      (c) => String(c[0]) === "/api/auth/github" && (c[1] as RequestInit | undefined)?.method === "POST",
+    );
+    expect(connect).toBeDefined();
+    expect(JSON.parse(String((connect![1] as RequestInit).body))).toEqual({ token: "ghp_testtoken" });
+
+    fireEvent.click(within(panel).getByText("acme/mycel"));
+    fireEvent.change(within(panel).getByLabelText("Clone target directory"), {
+      target: { value: "/tmp/src" },
+    });
+    fireEvent.click(within(panel).getByRole("button", { name: "Clone" }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("create-agent-github-panel")).not.toBeInTheDocument();
+    });
+    expect((screen.getByPlaceholderText("/absolute/path/to/repo") as HTMLInputElement).value).toBe(
+      "/tmp/src/mycel",
+    );
+
+    const clone = fetchMock.mock.calls.find(
+      (c) => String(c[0]) === "/api/repos/clone" && (c[1] as RequestInit | undefined)?.method === "POST",
+    );
+    expect(clone).toBeDefined();
+    expect(JSON.parse(String((clone![1] as RequestInit).body))).toEqual({
+      url: "https://github.com/acme/mycel.git",
+      target: "/tmp/src",
+      name: "mycel",
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("agent-name"), {
+      target: { value: "bold-otter" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        (c) => String(c[0]) === "/api/agents" && (c[1] as RequestInit | undefined)?.method === "POST",
+      );
+      expect(post).toBeDefined();
+      const body = JSON.parse(String((post![1] as RequestInit).body)) as Record<string, unknown>;
+      expect(body.repo).toBe("/tmp/src/mycel");
+      expect(body.name).toBe("bold-otter");
+    });
+  });
+
+  it("reuses an existing GitHub token and lists repos without a connect form", async () => {
+    mockApi({ connected: true, login: "puneet" });
+    renderModal();
+    await openGithubPanel();
+    const panel = screen.getByTestId("create-agent-github-panel");
+    await waitFor(() => {
+      expect(within(panel).getByText("Connected as puneet")).toBeInTheDocument();
+    });
+    expect(within(panel).queryByLabelText("GitHub token")).not.toBeInTheDocument();
+    expect(within(panel).getByText("acme/mycel")).toBeInTheDocument();
+    expect(within(panel).getByText("acme/private-notes")).toBeInTheDocument();
+    expect(within(panel).getByText(/· private/)).toBeInTheDocument();
+  });
+
+  it("filters the listed GitHub repos by name", async () => {
+    mockApi({ connected: true });
+    renderModal();
+    await openGithubPanel();
+    const panel = screen.getByTestId("create-agent-github-panel");
+    await waitFor(() => {
+      expect(within(panel).getByText("acme/mycel")).toBeInTheDocument();
+    });
+    fireEvent.change(within(panel).getByLabelText("Filter GitHub repos"), {
+      target: { value: "notes" },
+    });
+    expect(within(panel).queryByText("acme/mycel")).not.toBeInTheDocument();
+    expect(within(panel).getByText("acme/private-notes")).toBeInTheDocument();
+  });
+
+  it("keeps Clone disabled until a repo is selected", async () => {
+    mockApi({ connected: true });
+    renderModal();
+    await openGithubPanel();
+    const panel = screen.getByTestId("create-agent-github-panel");
+    await waitFor(() => {
+      expect(within(panel).getByText("acme/mycel")).toBeInTheDocument();
+    });
+    expect(within(panel).getByRole("button", { name: "Clone" })).toBeDisabled();
+    fireEvent.click(within(panel).getByText("acme/mycel"));
+    expect(within(panel).getByRole("button", { name: "Clone" })).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
Finish GitHub repo discover and clone in Create Agent so a remote checkout binds the new agent the same way picking a local repo does. Fixes #3655.

## Changes
- Add client methods for `GET|POST|DELETE /api/auth/github`, `POST /api/repos/discover/github`, and `POST /api/repos/clone`
- Add a GitHub panel next to Browse in `CreateAgentModal`: connect or reuse a stored PAT, list/filter repos, clone into a target path, bind that path
- Cover the client methods and the modal flow with focused vitest coverage

## Test Plan
- [ ] `make check` passes
- [x] New/updated tests cover the change
- [ ] Manual testing done (describe below)

Focused web tests:
```
cd web && bun run test -- src/components/__tests__/CreateAgentModal.test.tsx src/components/__tests__/CreateAgentModalGithub.test.tsx src/components/__tests__/CreateAgentModalReadiness.test.tsx src/api/__tests__/client.test.ts
```
38 passed.

## Checklist
- [x] PR title follows conventional commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] No secrets or credentials in the diff
- [ ] Documentation updated (if applicable)


Made with [Cursor](https://cursor.com)