### PR TITLE
chore(web): FilterBar/PageHeader polish and Code tab search

### DIFF
--- a/web/src/components/code/CodeBrowser.tsx
+++ b/web/src/components/code/CodeBrowser.tsx
@@ -16,6 +16,7 @@
  *   GET /api/code/tree?path=&worktree=&show_hidden=
  *   GET /api/code/file?path=&worktree=
  *   GET /api/code/diff?worktree=&path=
+ *   GET /api/code/search?q=&worktree=&case=&regex=&path=
  */
 
 import Editor, { DiffEditor } from "@monaco-editor/react";
@@ -25,6 +26,7 @@ import { Link } from "react-router-dom";
 import { useTheme } from "../../context/ThemeContext";
 import { languageFromPath } from "../../utils/lang";
 import { MONO } from "../../utils/typography";
+import { CodeSearchPanel } from "./CodeSearchPanel";
 
 export interface FileNode {
   name: string;
@@ -293,6 +295,12 @@ interface CodeBrowserProps {
   emptyState?: ReactNode;
 }
 
+interface EditorLike {
+  dispose?: () => void;
+  revealLineInCenter?: (line: number) => void;
+  setPosition?: (pos: { lineNumber: number; column: number }) => void;
+}
+
 export function CodeBrowser({
   worktree,
   state: controlledState,
@@ -301,7 +309,8 @@ export function CodeBrowser({
   fullViewHref,
   emptyState,
 }: CodeBrowserProps) {
-  const editorRef = useRef<{ dispose?: () => void } | null>(null);
+  const editorRef = useRef<EditorLike | null>(null);
+  const revealLineRef = useRef<number | null>(null);
   useEffect(() => () => { editorRef.current?.dispose?.(); }, []);
 
   const { mode: themeMode } = useTheme();
@@ -428,11 +437,32 @@ export function CodeBrowser({
       if (node.is_dir) {
         toggleExpand(node.path);
       } else {
+        revealLineRef.current = null;
         update({ path: node.path });
       }
     },
     [toggleExpand, update],
   );
+
+  const openSearchHit = useCallback(
+    (hitPath: string, line: number) => {
+      revealLineRef.current = line;
+      update({ path: hitPath, viewMode: "plain" });
+      editorRef.current?.revealLineInCenter?.(line);
+      editorRef.current?.setPosition?.({ lineNumber: line, column: 1 });
+    },
+    [update],
+  );
+
+  const bindEditor = useCallback((editor: EditorLike) => {
+    editorRef.current = editor;
+    const line = revealLineRef.current;
+    if (line != null) {
+      editor.revealLineInCenter?.(line);
+      editor.setPosition?.({ lineNumber: line, column: 1 });
+      revealLineRef.current = null;
+    }
+  }, []);
 
   const rootKey = `${worktree}||${showHidden ? "1" : "0"}`;
   const rootEntries = treeCache[rootKey] ?? [];
@@ -483,6 +513,7 @@ export function CodeBrowser({
         <div className="flex-1 min-h-0 flex">
           {/* Tree pane */}
           <aside className="w-64 shrink-0 border-r border-mycel-border overflow-y-auto">
+            <CodeSearchPanel worktree={worktree} onOpen={openSearchHit} />
             {rootLoading && <TreeSkeleton />}
             {!rootLoading && rootError && (
               <div className="px-3 py-2 text-[11px] text-mycel-error">{rootError}</div>
@@ -541,7 +572,7 @@ export function CodeBrowser({
               worktree !== "main" &&
               viewMode === "diff" && (
                 <DiffEditor
-                  onMount={(editor) => { editorRef.current = editor as unknown as { dispose?: () => void }; }}
+                  onMount={(editor) => { bindEditor(editor as unknown as EditorLike); }}
                   theme={monacoTheme}
                   language={language}
                   original={baseContent.content}
@@ -563,7 +594,7 @@ export function CodeBrowser({
               !fileContent.binary &&
               (worktree === "main" || viewMode === "plain") && (
                 <Editor
-                  onMount={(editor) => { editorRef.current = editor as unknown as { dispose?: () => void }; }}
+                  onMount={(editor) => { bindEditor(editor as unknown as EditorLike); }}
                   theme={monacoTheme}
                   language={language}
                   value={fileContent.content}

--- a/web/src/components/code/CodeSearchPanel.tsx
+++ b/web/src/components/code/CodeSearchPanel.tsx
@@ -1,0 +1,138 @@
+/**
+ * Modest Code-tab search panel. Calls GET /api/code/search and opens
+ * matches in the surrounding CodeBrowser.
+ */
+import { useEffect, useState } from "react";
+import { ListSearchInput } from "../shared";
+import { MONO } from "../../utils/typography";
+
+export interface CodeSearchMatch {
+  path: string;
+  text: string;
+  line: number;
+  col: number;
+}
+
+interface SearchResponse {
+  matches?: CodeSearchMatch[];
+  truncated?: boolean;
+  elapsed_ms?: number;
+}
+
+async function fetchSearch(
+  q: string,
+  worktree: string,
+): Promise<SearchResponse> {
+  const qs = new URLSearchParams({ q, worktree, case: "1" });
+  const r = await fetch(`/api/code/search?${qs.toString()}`);
+  if (!r.ok) {
+    let msg = `search failed (${String(r.status)})`;
+    try {
+      const body = (await r.json()) as { error?: string };
+      if (body.error) msg = body.error;
+    } catch {
+      /* keep status fallback */
+    }
+    throw new Error(msg);
+  }
+  return (await r.json()) as SearchResponse;
+}
+
+export function CodeSearchPanel({
+  worktree,
+  onOpen,
+}: {
+  worktree: string;
+  onOpen: (path: string, line: number) => void;
+}) {
+  const [q, setQ] = useState("");
+  const [matches, setMatches] = useState<CodeSearchMatch[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [truncated, setTruncated] = useState(false);
+
+  useEffect(() => {
+    const query = q.trim();
+    if (!query) {
+      setMatches([]);
+      setError(null);
+      setTruncated(false);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    const t = setTimeout(() => {
+      setLoading(true);
+      void fetchSearch(query, worktree)
+        .then((out) => {
+          if (cancelled) return;
+          setMatches(out.matches ?? []);
+          setTruncated(Boolean(out.truncated));
+          setError(null);
+        })
+        .catch((err: unknown) => {
+          if (cancelled) return;
+          setMatches([]);
+          setTruncated(false);
+          setError(err instanceof Error ? err.message : "search failed");
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, 280);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [q, worktree]);
+
+  const searching = q.trim().length > 0;
+
+  return (
+    <div className="border-b border-mycel-border" style={{ fontFamily: MONO }}>
+      <div className="p-2">
+        <ListSearchInput
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search code…"
+          aria-label="Search code"
+          className="w-full max-w-none min-w-0"
+          data-testid="code-search-input"
+        />
+      </div>
+      {searching && (
+        <div
+          className="max-h-56 overflow-y-auto border-t border-mycel-border"
+          data-testid="code-search-results"
+        >
+          {loading && (
+            <div className="px-3 py-2 text-[11px] text-mycel-muted">Searching…</div>
+          )}
+          {!loading && error && (
+            <div className="px-3 py-2 text-[11px] text-mycel-error">{error}</div>
+          )}
+          {!loading && !error && matches.length === 0 && (
+            <div className="px-3 py-2 text-[11px] text-mycel-muted italic">No matches</div>
+          )}
+          {!loading && !error && matches.map((m, i) => (
+            <button
+              key={`${m.path}:${String(m.line)}:${String(i)}`}
+              type="button"
+              onClick={() => onOpen(m.path, m.line)}
+              className="w-full text-left px-3 py-1.5 hover:bg-mycel-surface-hover border-b border-mycel-border/60 last:border-b-0"
+            >
+              <div className="text-[11px] text-mycel-accent truncate">
+                {m.path}
+                <span className="text-mycel-muted">:{String(m.line)}</span>
+              </div>
+              <div className="text-[11px] text-mycel-text-2 truncate">{m.text}</div>
+            </button>
+          ))}
+          {!loading && truncated && (
+            <div className="px-3 py-1.5 text-[10px] text-mycel-muted">Results truncated</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/views/About.tsx
+++ b/web/src/views/About.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { ExternalLink } from "../components/ExternalLink";
+import { PageHeader, SECONDARY_BTN } from "../components/shared";
 import { desktopAppVersion } from "../utils/desktopApp";
 
 /* ── Types ──────────────────────────────────────────────────────────── */
@@ -297,64 +298,55 @@ export function About() {
 
   return (
     <div className="p-6 flex flex-col gap-6 max-w-3xl mx-auto">
-      <header className="flex items-baseline justify-between gap-3">
-        <div className="flex items-baseline gap-3">
-          {/* Named for what it actually is. This number always comes from the
-              daemon's /api/health; calling it "Installed" inside the desktop app
-              invited reading it as the app's own version, which is a different
-              number whenever the app attached to a daemon it did not start. */}
-          <span className="text-[11px] uppercase tracking-wider text-mycel-muted">
-            {appVersion ? "Daemon" : "Installed"}
-          </span>
-          {/* A source build's version is long and full of hyphens, and wrapping
-              on one split it into "0.4.5-" / "dev.35.gfbc9a1c.dirty" — two
-              lines that read like two different numbers. It is one identifier,
-              so it is kept on one line and shrunk to fit. */}
-          <span className="text-xl sm:text-2xl font-semibold text-mycel-text font-mono tabular-nums whitespace-nowrap">
+      <PageHeader
+        eyebrow={appVersion ? "Daemon" : "Installed"}
+        title={
+          <span className="font-mono tabular-nums whitespace-nowrap">
             {health?.version ?? "—"}
           </span>
-          {appDiffersFromDaemon && (
-            <span
-              className="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 bg-mycel-warning-subtle text-mycel-warning ring-1 ring-inset ring-mycel-border"
-              title={
-                appRelation === "app-newer"
-                  ? `This desktop app is ${appVersion}, but it is using a separately running daemon on ${health?.version}. Restart the daemon from the newer build to match.`
-                  : appRelation === "daemon-newer"
-                    ? `This desktop app is ${appVersion}, older than the daemon on ${health?.version}. Relaunch the desktop app from the newer build to match.`
-                    : `This desktop app is ${appVersion}; the daemon is ${health?.version}.`
-              }
-            >
-              app is {appVersion}
-            </span>
-          )}
-          {/* Compare like-with-like. `latestTag` is a released version
-              ("0.3.1"), so only a build that claims to *be* a release can
-              meaningfully be behind one. Fixes #3212. */}
-          {(() => {
-            if (!latestTag || !health?.version) return null;
-            if (!isReleaseVersion(health.version)) {
-              return (
-                <span className="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 bg-mycel-info-subtle text-mycel-info ring-1 ring-inset ring-mycel-border">
-                  dev build
-                </span>
-              );
-            }
-            return health.version !== latestTag ? (
-              <span className="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 bg-mycel-warning-subtle text-mycel-warning ring-1 ring-inset ring-mycel-border">
-                update available
+        }
+        actions={
+          <>
+            {appDiffersFromDaemon && (
+              <span
+                className="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 bg-mycel-warning-subtle text-mycel-warning ring-1 ring-inset ring-mycel-border"
+                title={
+                  appRelation === "app-newer"
+                    ? `This desktop app is ${appVersion}, but it is using a separately running daemon on ${health?.version}. Restart the daemon from the newer build to match.`
+                    : appRelation === "daemon-newer"
+                      ? `This desktop app is ${appVersion}, older than the daemon on ${health?.version}. Relaunch the desktop app from the newer build to match.`
+                      : `This desktop app is ${appVersion}; the daemon is ${health?.version}.`
+                }
+              >
+                app is {appVersion}
               </span>
-            ) : null;
-          })()}
-        </div>
-        <button
-          type="button"
-          onClick={() => void refresh()}
-          disabled={loading}
-          className="text-[11px] px-2.5 py-1 rounded border border-mycel-border hover:border-mycel-accent bg-mycel-surface text-mycel-muted hover:text-mycel-text transition-colors disabled:opacity-50"
-        >
-          {loading ? "Refreshing…" : "Refresh"}
-        </button>
-      </header>
+            )}
+            {(() => {
+              if (!latestTag || !health?.version) return null;
+              if (!isReleaseVersion(health.version)) {
+                return (
+                  <span className="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 bg-mycel-info-subtle text-mycel-info ring-1 ring-inset ring-mycel-border">
+                    dev build
+                  </span>
+                );
+              }
+              return health.version !== latestTag ? (
+                <span className="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 bg-mycel-warning-subtle text-mycel-warning ring-1 ring-inset ring-mycel-border">
+                  update available
+                </span>
+              ) : null;
+            })()}
+            <button
+              type="button"
+              onClick={() => void refresh()}
+              disabled={loading}
+              className={SECONDARY_BTN}
+            >
+              {loading ? "Refreshing…" : "Refresh"}
+            </button>
+          </>
+        }
+      />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-px rounded-md border border-mycel-border bg-mycel-border overflow-hidden shadow-mycel">
         {channels.map((c, i) => (

--- a/web/src/views/AppsActivity.tsx
+++ b/web/src/views/AppsActivity.tsx
@@ -32,6 +32,7 @@ import { sourcePlatform } from "../components/apps/messageUtils";
 import { IdentityAvatar } from "../components/apps/IdentityAvatar";
 import { parseActivityTs } from "../components/apps/appStatus";
 import { formatRelative } from "../utils/time";
+import { ListSearchInput } from "../components/shared";
 
 /* ── Config ──────────────────────────────────────────────────── */
 
@@ -137,12 +138,11 @@ export function AppsActivity() {
     ),
     actions: (
       <>
-        <input
+        <ListSearchInput
           type="text"
           value={search}
           onChange={(e) => { setSearch(e.target.value); }}
           placeholder="Search messages"
-          className="flex-1 min-w-[96px] max-w-md h-9 px-3 text-sm rounded-md border border-mycel-border bg-mycel-surface text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent"
           aria-label="Search messages"
         />
         <select

--- a/web/src/views/Home.tsx
+++ b/web/src/views/Home.tsx
@@ -6,6 +6,7 @@ import { flattenNodes, nodeMatchesSearch } from "../components/live/liveHelpers"
 import { AgentCard, AgentDrillDown } from "../components/live/LiveRenderers";
 
 import { useHeaderSlot } from "../context/HeaderSlotContext";
+import { ListSearchInput } from "../components/shared";
 import { OverviewStrip } from "./home/OverviewStrip";
 import { ActivityFeed } from "./home/ActivityFeed";
 import { CostCharts } from "./home/CostCharts";
@@ -421,22 +422,15 @@ export function Home() {
     ),
     actions: drillDownAgent ? undefined : (
       <>
-        {/* Search — grows into the free header space, capped at max-w-lg */}
-        <div className="relative flex-1 min-w-0 max-w-lg">
-          <svg width="13" height="13" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className="absolute left-2.5 top-1/2 -translate-y-1/2 text-mycel-muted pointer-events-none">
-            <circle cx="6" cy="6" r="4.5" />
-            <path d="M9.5 9.5L13 13" />
-          </svg>
-          <input
-            ref={searchInputRef}
-            type="text"
-            value={searchFilter}
-            onChange={(e) => setSearchFilter(e.target.value)}
-            placeholder="Search  /"
-            aria-label="Search events"
-            className="w-full h-9 text-sm rounded-md border border-mycel-border bg-mycel-surface pl-8 pr-2.5 text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent"
-          />
-        </div>
+        {/* Search — shared ListSearchInput, same tokens as Agents / Apps */}
+        <ListSearchInput
+          ref={searchInputRef}
+          type="text"
+          value={searchFilter}
+          onChange={(e) => setSearchFilter(e.target.value)}
+          placeholder="Search  /"
+          aria-label="Search events"
+        />
 
         {/* ⋯ menu: pause, type filter, export, shortcuts */}
         <div className="relative shrink-0" ref={menuRef}>

--- a/web/src/views/Insights.tsx
+++ b/web/src/views/Insights.tsx
@@ -33,6 +33,7 @@ import type {
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
+import { PageHeader } from "../components/shared";
 import { SectionRule } from "../components/shared/SectionRule";
 import { fmtTokens } from "../components/shared/stats-primitives";
 import { AgentChip } from "../components/agent-ui";
@@ -623,6 +624,10 @@ export function Insights() {
     // still renders here.
     return (
       <div className="p-6 max-w-6xl mx-auto space-y-8">
+        <PageHeader
+          title="Insights"
+          subtitle="Spend, attribution, and activity for the whole fleet."
+        />
         <EmptyState
           icon="$"
           title={isAll ? "No cost data yet" : `No spend in the ${periodLabel}`}
@@ -637,6 +642,10 @@ export function Insights() {
 
   return (
     <div className="p-6 max-w-6xl mx-auto space-y-8">
+      <PageHeader
+        title="Insights"
+        subtitle="Spend, attribution, and activity for the whole fleet."
+      />
       {/* ── Stat band — four numbers, hairline-divided, period-scoped ── */}
       <div className="rounded-lg border border-mycel-border shadow-mycel-sm overflow-hidden">
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-px bg-mycel-border">

--- a/web/src/views/Marketplace.tsx
+++ b/web/src/views/Marketplace.tsx
@@ -11,7 +11,7 @@ import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
 import { ExternalLink } from "../components/ExternalLink";
-import { FILTER_INLINE_BTN_CLS, LIST_SEARCH_CLS } from "../components/shared";
+import { FILTER_INLINE_BTN_CLS, ListSearchInput } from "../components/shared";
 import { useHeaderSlot } from "../context/HeaderSlotContext";
 
 // How many cards to mount at once. The full catalog is ~1.5k items; mounting
@@ -588,12 +588,11 @@ export function Marketplace() {
     <div className="flex flex-col gap-4 p-4 max-w-4xl mx-auto w-full">
       {/* Filter bar — shared search/chip tokens with Agents + Apps (#3671) */}
       <div className="flex flex-wrap gap-2 items-center" data-testid="marketplace-filter-bar">
-        <input
-          type="search"
+        <ListSearchInput
           placeholder="Search catalog…"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          className={`${LIST_SEARCH_CLS} min-w-[180px]`}
+          className="min-w-[180px]"
           aria-label="Search catalog"
         />
         <FilterSelect

--- a/web/src/views/Templates.tsx
+++ b/web/src/views/Templates.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
 import { usePolling } from "../hooks/usePolling";
-import { ChipList, SectionRule, ConfirmButton, PRIMARY_BTN } from "../components/shared";
+import { ChipList, SectionRule, ConfirmButton, PRIMARY_BTN, ListSearchInput } from "../components/shared";
 import { MONO } from "../utils/typography";
 
 import { useHeaderSlot } from "../context/HeaderSlotContext";
@@ -807,12 +807,11 @@ export function Templates() {
     actions:
       selectedTemplate === null ? (
         <>
-          <input
+          <ListSearchInput
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search templates..."
-            className="flex-1 min-w-[96px] max-w-md h-9 px-3 text-sm rounded-md border border-mycel-border bg-mycel-surface text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent"
             aria-label="Search templates"
           />
           <button

--- a/web/src/views/__tests__/insights.test.tsx
+++ b/web/src/views/__tests__/insights.test.tsx
@@ -195,6 +195,12 @@ describe("Insights", () => {
       expect(screen.queryByText(gone)).not.toBeInTheDocument();
     }
   });
+
+  it("uses the shared PageHeader", async () => {
+    renderInsights();
+    await waitFor(() => expect(screen.getByTestId("page-header")).toBeInTheDocument());
+    expect(screen.getByRole("heading", { name: "Insights" })).toBeInTheDocument();
+  });
 });
 
 describe("summarizeActivity", () => {

--- a/web/src/views/__tests__/views.test.tsx
+++ b/web/src/views/__tests__/views.test.tsx
@@ -367,6 +367,47 @@ describe("CodeBrowser", () => {
     expect(screen.getByText("Select a file from the tree")).toBeInTheDocument();
   });
 
+  it("searches the worktree via /api/code/search and lists matches", async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("/api/code/search")) {
+        return jsonResponse({
+          matches: [{ path: "main.go", line: 12, col: 1, text: "func main()" }],
+          truncated: false,
+        });
+      }
+      if (u.includes("/api/code/tree")) {
+        return jsonResponse([
+          { name: "src", path: "src", is_dir: true },
+          { name: "main.go", path: "main.go", is_dir: false, size: 42 },
+        ]);
+      }
+      return jsonResponse([]);
+    });
+
+    render(
+      <MemoryRouter>
+        <CodeBrowser
+          worktree="bot-1"
+          embedded
+          fullViewHref="/code?worktree=bot-1"
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText("Search code"), { target: { value: "func main" } });
+    await waitFor(() => {
+      expect(screen.getByTestId("code-search-results")).toHaveTextContent("func main()");
+    });
+    expect(
+      fetchMock.mock.calls.some((c) => String(c[0]).includes("/api/code/search?")),
+    ).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: /main\.go:12/ }));
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some((c) => String(c[0]).includes("/api/code/file?"))).toBe(true);
+    });
+  });
+
   it("renders the provided emptyState when the worktree has no files", async () => {
     fetchMock.mockReturnValue(jsonResponse([]));
 


### PR DESCRIPTION
## Summary
- Migrate remaining list searches (Templates, AppsActivity, Home, Marketplace) onto shared `ListSearchInput` / FilterBar primitives after #3671.
- Adopt shared `PageHeader` on About and Insights, matching Settings/Readiness.
- Ship a modest Code-tab search panel that calls `/api/code/search` and opens matches in the browser.

Fixes #3690
Fixes #3691
Fixes #3692

Part of #3624.

## Test plan
- [ ] Templates / Apps activity / Home / Marketplace search still filters lists and keeps the same header layout
- [ ] About and Insights render `data-testid="page-header"` with Refresh / period controls unchanged
- [ ] Code tab: type a query, see matches, click one to open the file (and jump to line when Monaco mounts)
- [ ] `bun run test -- src/views/__tests__/views.test.tsx src/views/__tests__/insights.test.tsx src/views/__tests__/appsActivity.test.tsx src/views/__tests__/templates.test.tsx`


Made with [Cursor](https://cursor.com)