### PR TITLE
fix(gateway,notify): adapter health mirrors AdapterStatus; persist skipped deliveries

### DIFF
--- a/pkg/notify/api_test.go
+++ b/pkg/notify/api_test.go
@@ -1524,3 +1524,44 @@ func TestMultipleChannelsIndependence(t *testing.T) {
 		t.Fatalf("expected 3 total subscriptions, got %d", len(allSubs))
 	}
 }
+
+func TestChannelDetailIncludesLastDelivery(t *testing.T) {
+	store := setupStore(t)
+	ctx := context.Background()
+	if err := store.Subscribe(ctx, "slack:eng", "eng-01", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.LogDelivery(ctx, notify.DeliveryEntry{
+		Channel: "slack:eng",
+		Agent:   "eng-01",
+		Status:  notify.StatusSkipped,
+		Error:   "agent eng-01 is stopped",
+		Preview: "hello",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	svc, _ := setupService(store)
+	ts := setupHandler(t, svc)
+
+	resp := doJSON(t, http.MethodGet, ts.URL+"/api/apps/slack/channels/eng", nil) //nolint:bodyclose // closed via t.Cleanup in doJSON
+	assertStatus(t, resp, http.StatusOK)
+
+	var body struct {
+		ChannelKey   string                `json:"channel_key"`
+		LastDelivery *notify.DeliveryEntry `json:"last_delivery"`
+	}
+	decodeJSON(t, resp, &body)
+	if body.ChannelKey != "slack:eng" {
+		t.Errorf("channel_key = %q, want slack:eng", body.ChannelKey)
+	}
+	if body.LastDelivery == nil {
+		t.Fatal("expected last_delivery")
+	}
+	if body.LastDelivery.Status != notify.StatusSkipped {
+		t.Errorf("last_delivery.status = %q, want skipped", body.LastDelivery.Status)
+	}
+	if body.LastDelivery.Agent != "eng-01" {
+		t.Errorf("last_delivery.agent = %q, want eng-01", body.LastDelivery.Agent)
+	}
+}

--- a/pkg/notify/api_test.go
+++ b/pkg/notify/api_test.go
@@ -1548,8 +1548,8 @@ func TestChannelDetailIncludesLastDelivery(t *testing.T) {
 	assertStatus(t, resp, http.StatusOK)
 
 	var body struct {
-		ChannelKey   string                `json:"channel_key"`
 		LastDelivery *notify.DeliveryEntry `json:"last_delivery"`
+		ChannelKey   string                `json:"channel_key"`
 	}
 	decodeJSON(t, resp, &body)
 	if body.ChannelKey != "slack:eng" {

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -19,6 +19,11 @@ const (
 	StatusDelivered DeliveryStatus = "delivered"
 	StatusFailed    DeliveryStatus = "failed"
 	StatusPending   DeliveryStatus = "pending"
+	// StatusSkipped is a subscribed agent that was offline when the
+	// message arrived — the routing decision was correct, delivery
+	// just was not attempted. Distinct from StatusFailed so activity
+	// counts do not treat routine offline misses as send errors.
+	StatusSkipped DeliveryStatus = "skipped"
 )
 
 // Notification is the JSON payload sent to subscribed agents via tmux send-keys.

--- a/pkg/notify/pagination_test.go
+++ b/pkg/notify/pagination_test.go
@@ -3,6 +3,8 @@ package notify
 import (
 	"context"
 	"testing"
+
+	"github.com/rpuneet/mycel/pkg/db"
 )
 
 // TestStore_IndexesPresent asserts the schema self-creates the indexes the
@@ -25,6 +27,42 @@ func TestStore_IndexesPresent(t *testing.T) {
 		if err != nil {
 			t.Errorf("expected index %q to exist: %v", name, err)
 		}
+	}
+}
+
+func TestStore_MigratesSkippedDeliveryStatus(t *testing.T) {
+	d, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	_, err = d.ExecContext(context.Background(), `
+CREATE TABLE notify_delivery_log (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    logged_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    channel   TEXT NOT NULL,
+    agent     TEXT NOT NULL,
+    status    TEXT NOT NULL CHECK(status IN ('delivered', 'failed', 'pending')),
+    error     TEXT,
+    preview   TEXT
+)`)
+	if err != nil {
+		t.Fatalf("seed old table: %v", err)
+	}
+
+	store, err := OpenStore(d, "sqlite")
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	if err := store.LogDelivery(context.Background(), DeliveryEntry{
+		Channel: "slack:eng",
+		Agent:   "bot",
+		Status:  StatusSkipped,
+		Error:   "agent bot is stopped",
+		Preview: "hi",
+	}); err != nil {
+		t.Fatalf("LogDelivery skipped: %v", err)
 	}
 }
 

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -360,13 +360,11 @@ func (s *Service) deliverToSubscribers(ctx context.Context, d deliverable) {
 		case sendErr == nil:
 			log.Info("notify: delivered", "agent", sub.Agent, "channel", channel)
 		case agentOfflineRe.MatchString(sendErr.Error()):
-			// Subscribed agent was offline when the message arrived
-			// — the routing decision was correct, delivery just
-			// wasn't attempted. Skip the delivery-log write entirely
-			// so the failed-delivery count only reflects genuine
-			// send errors, not routine offline-agent skips.
+			// Persist as skipped so the activity UI counts the miss
+			// without inflating failed-delivery totals (#3694).
+			status = StatusSkipped
+			errStr = sendErr.Error()
 			log.Debug("notify: delivery skipped (agent offline)", "agent", sub.Agent, "channel", channel)
-			continue
 		default:
 			status = StatusFailed
 			errStr = sendErr.Error()
@@ -602,9 +600,9 @@ func (s *Service) deliverOutboundToSubscribers(ctx context.Context, channel, sen
 		case sendErr == nil:
 			log.Info("notify: outbound delivered", "agent", sub.Agent, "channel", channel)
 		case agentOfflineRe.MatchString(sendErr.Error()):
-			// Subscribed agent was offline when the message arrived
+			status = StatusSkipped
+			errStr = sendErr.Error()
 			log.Debug("notify: outbound delivery skipped (agent offline)", "agent", sub.Agent, "channel", channel)
-			continue
 		default:
 			status = StatusFailed
 			errStr = sendErr.Error()

--- a/pkg/notify/service_test.go
+++ b/pkg/notify/service_test.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 
 // mockSender records SendToAgent calls.
 type mockSender struct {
+	errFn func(name string) error
 	calls []sendCall
 	mu    sync.Mutex
 }
@@ -24,6 +26,9 @@ func (m *mockSender) Send(_ context.Context, name, message string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.calls = append(m.calls, sendCall{Name: name, Message: message})
+	if m.errFn != nil {
+		return m.errFn(name)
+	}
 	return nil
 }
 
@@ -706,6 +711,67 @@ func TestDispatchWithoutAutomatedStillDelivers(t *testing.T) {
 	calls := sender.getCalls()
 	if len(calls) != 1 || calls[0].Name != "fast-crane" {
 		t.Fatalf("expected one delivery to fast-crane, got %+v", calls)
+	}
+}
+
+func TestDispatchOfflineAgentLogsSkipped(t *testing.T) {
+	store := setupTestStore(t)
+	sender := &mockSender{errFn: func(name string) error {
+		return fmt.Errorf("agent %s is stopped", name)
+	}}
+	svc := NewService(store, sender, &mockHub{})
+	ctx := context.Background()
+
+	if err := store.Subscribe(ctx, "slack:eng", "offline-bot", false); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.Dispatch("slack:eng", "slack", "alice", "U1", "", "hello fleet", "m1", nil, nil, nil)
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch did not finish")
+	}
+
+	entries, err := store.RecentActivity(ctx, "slack:eng", 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 skipped delivery row, got %+v", entries)
+	}
+	if entries[0].Status != StatusSkipped {
+		t.Errorf("status = %q, want %q", entries[0].Status, StatusSkipped)
+	}
+	if entries[0].Agent != "offline-bot" {
+		t.Errorf("agent = %q, want offline-bot", entries[0].Agent)
+	}
+	if entries[0].Error == "" {
+		t.Error("expected offline error text on skipped row")
+	}
+}
+
+func TestDispatchSendErrorLogsFailedNotSkipped(t *testing.T) {
+	store := setupTestStore(t)
+	sender := &mockSender{errFn: func(string) error {
+		return fmt.Errorf("tmux session not found")
+	}}
+	svc := NewService(store, sender, &mockHub{})
+	ctx := context.Background()
+
+	if err := store.Subscribe(ctx, "slack:eng", "eng-01", false); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.Dispatch("slack:eng", "slack", "alice", "U1", "", "hello", "m1", nil, nil, nil)
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch did not finish")
+	}
+
+	entries, err := store.RecentActivity(ctx, "slack:eng", 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Status != StatusFailed {
+		t.Fatalf("expected 1 failed row, got %+v", entries)
 	}
 }
 

--- a/pkg/notify/store.go
+++ b/pkg/notify/store.go
@@ -81,7 +81,63 @@ func (s *Store) initSchema() error {
 	if err := s.migrateLegacyCatchAll(context.TODO()); err != nil {
 		return fmt.Errorf("migrate legacy catch-all: %w", err)
 	}
+	if err := s.migrateDeliveryStatusSkipped(context.TODO()); err != nil {
+		return fmt.Errorf("migrate delivery status skipped: %w", err)
+	}
 	return nil
+}
+
+// migrateDeliveryStatusSkipped widens notify_delivery_log's status CHECK so
+// offline-agent rows can persist as 'skipped' (#3694). SQLite cannot ALTER a
+// CHECK, so existing DBs rebuild the table; Postgres drops/re-adds the
+// named constraint. Idempotent when 'skipped' is already allowed.
+func (s *Store) migrateDeliveryStatusSkipped(ctx context.Context) error {
+	if s.driver == "timescale" {
+		_, err := s.db.ExecContext(ctx, `
+ALTER TABLE notify_delivery_log DROP CONSTRAINT IF EXISTS notify_delivery_log_status_check;
+ALTER TABLE notify_delivery_log ADD CONSTRAINT notify_delivery_log_status_check
+  CHECK (status IN ('delivered', 'failed', 'pending', 'skipped'))`)
+		return err
+	}
+
+	var ddl string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name='notify_delivery_log'`).Scan(&ddl)
+	if err != nil {
+		return err
+	}
+	if strings.Contains(ddl, "'skipped'") {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmts := []string{
+		`CREATE TABLE notify_delivery_log_new (
+			id        INTEGER PRIMARY KEY AUTOINCREMENT,
+			logged_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+			channel   TEXT NOT NULL,
+			agent     TEXT NOT NULL,
+			status    TEXT NOT NULL CHECK(status IN ('delivered', 'failed', 'pending', 'skipped')),
+			error     TEXT,
+			preview   TEXT
+		)`,
+		`INSERT INTO notify_delivery_log_new (id, logged_at, channel, agent, status, error, preview)
+		 SELECT id, logged_at, channel, agent, status, error, preview FROM notify_delivery_log`,
+		`DROP TABLE notify_delivery_log`,
+		`ALTER TABLE notify_delivery_log_new RENAME TO notify_delivery_log`,
+		`CREATE INDEX IF NOT EXISTS idx_notify_delivery_channel ON notify_delivery_log(channel, id DESC)`,
+	}
+	for _, stmt := range stmts {
+		if _, execErr := tx.ExecContext(ctx, stmt); execErr != nil {
+			return execErr
+		}
+	}
+	return tx.Commit()
 }
 
 // migrateLegacyCatchAll rewrites "{platform}:general" subscription rows to
@@ -156,7 +212,7 @@ CREATE TABLE IF NOT EXISTS notify_delivery_log (
     logged_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
     channel   TEXT NOT NULL,
     agent     TEXT NOT NULL,
-    status    TEXT NOT NULL CHECK(status IN ('delivered', 'failed', 'pending')),
+    status    TEXT NOT NULL CHECK(status IN ('delivered', 'failed', 'pending', 'skipped')),
     error     TEXT,
     preview   TEXT
 );
@@ -214,7 +270,7 @@ CREATE TABLE IF NOT EXISTS notify_delivery_log (
     logged_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     channel   TEXT NOT NULL,
     agent     TEXT NOT NULL,
-    status    TEXT NOT NULL CHECK(status IN ('delivered', 'failed', 'pending')),
+    status    TEXT NOT NULL CHECK(status IN ('delivered', 'failed', 'pending', 'skipped')),
     error     TEXT,
     preview   TEXT
 );

--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -103,6 +103,9 @@ func (h *GatewayHandler) gatewayAPIProxy(w http.ResponseWriter, r *http.Request,
 }
 
 // gatewayHealth returns live health status for a gateway adapter.
+// The payload mirrors gateway.AdapterStatus (bot_name, message_count,
+// last_message_at, error) plus a derived status string. Unregistered
+// adapters return 404 rather than 200 with an error string (#3693).
 func (h *GatewayHandler) gatewayHealth(w http.ResponseWriter, r *http.Request, platform string) {
 	if !requireMethod(w, r, http.MethodGet) {
 		return
@@ -111,16 +114,28 @@ func (h *GatewayHandler) gatewayHealth(w http.ResponseWriter, r *http.Request, p
 		serviceUnavailable(w, r, "gateway", "gateway manager not available")
 		return
 	}
+	if h.gw.GetAdapter(platform) == nil {
+		httpError(w, "adapter not found: "+platform, http.StatusNotFound)
+		return
+	}
 
 	status := h.gw.AdapterStatus(platform)
-
-	writeJSON(w, http.StatusOK, map[string]any{
-		"platform":        platform,
-		"connected":       status.Connected,
-		"status":          map[bool]string{true: "ok", false: "disconnected"}[status.Connected],
-		"error":           status.Error,
-		"last_message_at": status.LastMessageAt,
-	})
+	body := map[string]any{
+		"platform":      platform,
+		"connected":     status.Connected,
+		"status":        map[bool]string{true: "ok", false: "disconnected"}[status.Connected],
+		"message_count": status.MessageCount,
+	}
+	if status.BotName != "" {
+		body["bot_name"] = status.BotName
+	}
+	if status.Error != "" {
+		body["error"] = status.Error
+	}
+	if !status.LastMessageAt.IsZero() {
+		body["last_message_at"] = status.LastMessageAt
+	}
+	writeJSON(w, http.StatusOK, body)
 }
 
 // gatewayChannels handles /api/apps/{name}/channels and sub-routes.
@@ -200,11 +215,18 @@ func (h *GatewayHandler) gatewayChannels(w http.ResponseWriter, r *http.Request,
 		if subs == nil {
 			subs = []notify.Subscription{}
 		}
+		var last *notify.DeliveryEntry
+		if activity, actErr := h.notifySvc.ChannelActivity(r.Context(), channelName, 1, 0); actErr != nil {
+			log.Warn("channel detail: last delivery", "channel", channelName, "error", actErr)
+		} else if len(activity) > 0 {
+			last = &activity[0]
+		}
 		writeJSON(w, http.StatusOK, map[string]any{
 			"channel_key":   channelName,
 			"name":          channelParts[0],
 			"platform":      platform,
 			"subscriptions": subs,
+			"last_delivery": last,
 		})
 	}
 }

--- a/server/handlers/gateways_test.go
+++ b/server/handlers/gateways_test.go
@@ -462,3 +462,62 @@ func TestChannelSend_MissingFields(t *testing.T) {
 		})
 	}
 }
+
+func TestGatewayHealthMirrorsAdapterStatus(t *testing.T) {
+	gw := gateway.NewManager()
+	gw.Register(&stubAdapter{
+		name: "slack",
+		status: gateway.AdapterStatus{
+			Connected:    true,
+			BotName:      "mycel-bot",
+			MessageCount: 42,
+			Error:        "",
+		},
+	})
+	h := &GatewayHandler{gw: gw}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/apps/slack/health", nil)
+	rr := httptest.NewRecorder()
+	h.gatewayHealth(rr, req, "slack")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+
+	var body struct {
+		Platform     string `json:"platform"`
+		Status       string `json:"status"`
+		BotName      string `json:"bot_name"`
+		Error        string `json:"error"`
+		Connected    bool   `json:"connected"`
+		MessageCount int64  `json:"message_count"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Platform != "slack" || !body.Connected || body.Status != "ok" {
+		t.Errorf("got %+v, want slack connected/ok", body)
+	}
+	if body.BotName != "mycel-bot" {
+		t.Errorf("bot_name = %q, want mycel-bot", body.BotName)
+	}
+	if body.MessageCount != 42 {
+		t.Errorf("message_count = %d, want 42", body.MessageCount)
+	}
+	if body.Error != "" {
+		t.Errorf("error = %q, want empty", body.Error)
+	}
+}
+
+func TestGatewayHealthUnregistered404(t *testing.T) {
+	gw := gateway.NewManager()
+	h := &GatewayHandler{gw: gw}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/apps/nope/health", nil)
+	rr := httptest.NewRecorder()
+	h.gatewayHealth(rr, req, "nope")
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/web/src/__tests__/apps-e2e.test.ts
+++ b/web/src/__tests__/apps-e2e.test.ts
@@ -348,33 +348,42 @@ describe("Apps Page E2E", () => {
 
     // Health endpoint
     describe("GET /api/apps/{name}/health", () => {
-      it("returns 200 with platform, connected, status fields for slack", async () => {
+      it("returns AdapterStatus fields when the adapter is registered, or 404 if not", async () => {
         if (!serverAvailable) return;
         const { status, body } = await apiFetch("/apps/slack/health");
-        expect(status).toBe(200);
+        expect([200, 404]).toContain(status);
         const resp = body as Record<string, unknown>;
+        if (status === 404) {
+          expect(typeof resp.error).toBe("string");
+          return;
+        }
         expect(resp.platform).toBe("slack");
         expect(typeof resp.connected).toBe("boolean");
         expect(typeof resp.status).toBe("string");
         expect(resp.status === "ok" || resp.status === "disconnected").toBe(true);
+        expect(typeof resp.message_count).toBe("number");
       });
 
-      it("returns 200 with platform=telegram for telegram health check", async () => {
+      it("returns 200 or 404 for telegram health check", async () => {
         if (!serverAvailable) return;
         const { status, body } = await apiFetch("/apps/telegram/health");
-        expect(status).toBe(200);
-        const resp = body as Record<string, unknown>;
-        expect(resp.platform).toBe("telegram");
-        expect(typeof resp.connected).toBe("boolean");
+        expect([200, 404]).toContain(status);
+        if (status === 200) {
+          const resp = body as Record<string, unknown>;
+          expect(resp.platform).toBe("telegram");
+          expect(typeof resp.connected).toBe("boolean");
+        }
       });
 
-      it("returns 200 with platform=discord for discord health check", async () => {
+      it("returns 200 or 404 for discord health check", async () => {
         if (!serverAvailable) return;
         const { status, body } = await apiFetch("/apps/discord/health");
-        expect(status).toBe(200);
-        const resp = body as Record<string, unknown>;
-        expect(resp.platform).toBe("discord");
-        expect(typeof resp.connected).toBe("boolean");
+        expect([200, 404]).toContain(status);
+        if (status === 200) {
+          const resp = body as Record<string, unknown>;
+          expect(resp.platform).toBe("discord");
+          expect(typeof resp.connected).toBe("boolean");
+        }
       });
     });
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -176,7 +176,7 @@ export interface DeliveryEntry {
   logged_at: string;
   channel: string;
   agent: string;
-  status: "delivered" | "failed" | "pending";
+  status: "delivered" | "failed" | "pending" | "skipped";
   error?: string;
   preview?: string;
 }
@@ -276,6 +276,8 @@ export interface GatewayHealth {
   status: string;
   error?: string;
   last_message_at?: string;
+  bot_name?: string;
+  message_count?: number;
 }
 
 export function instancesToStatuses(instances: AppInstance[]): GatewayStatus[] {

--- a/web/src/components/apps/GatewayFeed.tsx
+++ b/web/src/components/apps/GatewayFeed.tsx
@@ -754,6 +754,7 @@ export function GatewayFeed({
   const liveCount = subscribedAgents.filter(
     (a) => a.state === "running" || a.state === "working",
   ).length;
+  const lastDelivery = deliveries[0];
 
   // Back/forward now lives once, in the header (HistoryNavButtons) —
   // this view no longer grows its own back button.
@@ -795,9 +796,29 @@ export function GatewayFeed({
         >
           {messages.length} msgs
         </span>
+        {lastDelivery && (
+          <span
+            className="hidden md:inline shrink-0 truncate max-w-[14rem]"
+            data-testid="channel-last-delivery"
+            title={`${lastDelivery.status} → ${lastDelivery.agent}${lastDelivery.error ? `: ${lastDelivery.error}` : ""}`}
+            style={{
+              color:
+                lastDelivery.status === "failed"
+                  ? "var(--mycel-error)"
+                  : lastDelivery.status === "skipped"
+                    ? "var(--mycel-warning)"
+                    : "var(--mycel-muted)",
+              fontSize: 11,
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            last {lastDelivery.status}
+            {lastDelivery.agent ? ` · ${lastDelivery.agent}` : ""}
+          </span>
+        )}
       </div>
     ),
-    [channelLabel, platform, PlatformGlyph, messages.length],
+    [channelLabel, platform, PlatformGlyph, messages.length, lastDelivery],
   );
 
   const headerActions = useMemo(
@@ -1415,7 +1436,8 @@ export function GatewayFeed({
                           const msgDeliveries = deliveryByPreview.get(preview) ?? [];
                           const delivered = msgDeliveries.filter((d) => d.status === "delivered");
                           const failed = msgDeliveries.filter((d) => d.status === "failed");
-                          const hasDelivery = delivered.length > 0 || failed.length > 0;
+                          const skipped = msgDeliveries.filter((d) => d.status === "skipped");
+                          const hasDelivery = delivered.length > 0 || failed.length > 0 || skipped.length > 0;
                           // Detect webhook JSON payloads on any platform
                           const looksLikeWebhook = msg.content.trimStart().startsWith("{") &&
                             /pull_request|"issue"|"ref".*"commits"|"action"/i.test(msg.content);
@@ -1470,6 +1492,11 @@ export function GatewayFeed({
                                     {failed.length > 0 && (
                                       <span style={{ color: "color-mix(in oklab, var(--mycel-error) 50%, transparent)" }} title={failed.map((d) => `${d.agent}: ${d.error ?? "failed"}`).join(", ")}>
                                         ✗ {failed.map((d) => d.agent).join(", ")}
+                                      </span>
+                                    )}
+                                    {skipped.length > 0 && (
+                                      <span style={{ color: "color-mix(in oklab, var(--mycel-warning) 50%, transparent)" }} title={skipped.map((d) => `${d.agent}: ${d.error ?? "offline"}`).join(", ")}>
+                                        skipped {skipped.map((d) => d.agent).join(", ")}
                                       </span>
                                     )}
                                   </div>


### PR DESCRIPTION
## Summary
- Adapter `/health` now mirrors `AdapterStatus` (`bot_name`, `message_count`, omitted empty error / last_message_at) and returns **404** when the adapter is not registered instead of 200 with an error string.
- Offline-agent sends are persisted as `StatusSkipped` (schema CHECK widened, with a SQLite rebuild / Postgres constraint migration) so activity UI no longer undercounts misses.
- Channel detail includes `last_delivery`; the channel header surfaces last delivered/skipped/failed.

Fixes #3693
Fixes #3694

Part of #3624.

## Test plan
- [ ] `GET /api/apps/{registered}/health` includes `message_count` and `bot_name` when set
- [ ] `GET /api/apps/{unknown}/health` returns 404
- [ ] Dispatch to a stopped subscribed agent writes a `skipped` delivery-log row (not `failed`)
- [ ] Channel detail JSON has `last_delivery`; channel header shows `last skipped · agent`
- [ ] `go test ./pkg/notify/ ./server/handlers/ -run 'TestDispatchOffline|TestGatewayHealth|TestChannelDetailIncludesLastDelivery|TestStore_MigratesSkipped'`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Channel details now show the latest notification delivery, including its status and agent.
  - Offline agents are recorded as “Skipped” deliveries with relevant details.
  - Gateway health responses include connection information, bot name, and message counts when available.
  - Unregistered gateways now return a clear not-found response.
  - Delivery feeds display skipped deliveries with warning indicators and offline or error details.

- **Bug Fixes**
  - Improved handling of gateway health and delivery activity lookup issues without disrupting channel requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->