### PR TITLE
fix(desktop): enrich GUI PATH + bound Docker probes (tmux false-fail)

### DIFF
--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/rpuneet/mycel/internal/cmd"
+	"github.com/rpuneet/mycel/pkg/envpath"
 )
 
 // Version information set by ldflags during build.
@@ -15,6 +16,8 @@ var (
 )
 
 func main() {
+	// GUI / launchd PATH often omits Homebrew; enrich before any LookPath.
+	envpath.Enrich()
 	cmd.SetVersionInfo(version, commit, date)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 
 	"github.com/rpuneet/mycel/internal/cmd"
+	"github.com/rpuneet/mycel/pkg/envpath"
 	"github.com/rpuneet/mycel/pkg/log"
 )
 
@@ -29,6 +30,9 @@ var (
 )
 
 func main() {
+	// .app bundles inherit a minimal PATH (no Homebrew). Enrich before
+	// the embedded daemon LookPaths tmux/docker/agent CLIs.
+	envpath.Enrich()
 	cmd.SetVersionInfo(version, commit, date)
 
 	srv := NewServer()

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/rpuneet/mycel/pkg/home"
 	"github.com/rpuneet/mycel/pkg/log"
@@ -109,15 +109,16 @@ type Backend struct {
 	mu               sync.RWMutex
 }
 
+// dockerProbeTimeout bounds CLI probes used to decide whether Docker is
+// available. A wedged Docker Desktop must not block mycel boot or health
+// checks forever — unavailable after the deadline means "use tmux".
+const dockerProbeTimeout = 3 * time.Second
+
 // NewBackend creates a Docker runtime backend.
-// Returns an error if the Docker daemon is not reachable.
+// Returns an error if the Docker daemon is not reachable within dockerProbeTimeout.
 func NewBackend(cfg Config, prefix, repoPath string, registry *provider.Registry) (*Backend, error) {
-	ctx := context.Background()
-	cmd := exec.CommandContext(ctx, "docker", "info") //nolint:gosec // trusted binary
-	cmd.Stdout = io.Discard
-	cmd.Stderr = io.Discard
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("docker daemon not available: %w", err)
+	if err := probeDocker(context.Background(), "info"); err != nil {
+		return nil, err
 	}
 
 	// Use host repo path for volume mounts in Docker-in-Docker setups.
@@ -270,13 +271,13 @@ func (b *Backend) tmuxTarget(ctx context.Context, name string) string {
 // HasSession checks if a container exists, is running, AND has a live tmux
 // session inside. A container with only zombie processes is treated as dead
 // so the caller will respawn it rather than reusing a broken session.
+//
+// Probes are bounded by dockerProbeTimeout so a wedged Docker daemon cannot
+// stall agent health / reconcile loops that call HasSession on every tick.
 func (b *Backend) HasSession(ctx context.Context, name string) bool {
 	cn := b.containerName(name)
 
-	// Check container is running
-	//nolint:gosec // trusted
-	inspect := exec.CommandContext(ctx, "docker", "inspect", "--format", "{{.State.Running}}", cn)
-	out, err := inspect.Output()
+	out, err := probeDockerOutput(ctx, "inspect", "--format", "{{.State.Running}}", cn)
 	if err != nil || strings.TrimSpace(string(out)) != "true" {
 		return false
 	}
@@ -284,9 +285,7 @@ func (b *Backend) HasSession(ctx context.Context, name string) bool {
 	// Also verify at least one tmux session is alive inside the container.
 	// Claude --tmux creates sessions with varying names (workspace0, workspace_worktree-*).
 	// If all tmux sessions are dead (zombie), treat the container as gone.
-	//nolint:gosec // trusted
-	tmuxCheck := exec.CommandContext(ctx, "docker", "exec", cn, "tmux", "list-sessions")
-	return tmuxCheck.Run() == nil
+	return probeDocker(ctx, "exec", cn, "tmux", "list-sessions") == nil
 }
 
 // CreateSession creates a new container session.
@@ -675,10 +674,7 @@ func (b *Backend) AttachCmd(ctx context.Context, name string) *exec.Cmd {
 
 // IsRunning checks if the Docker daemon is running.
 func (b *Backend) IsRunning(ctx context.Context) bool {
-	cmd := exec.CommandContext(ctx, "docker", "info") //nolint:gosec // trusted binary
-	cmd.Stdout = io.Discard
-	cmd.Stderr = io.Discard
-	return cmd.Run() == nil
+	return probeDocker(ctx, "info") == nil
 }
 
 // KillServer stops and removes all mycel containers for this daemon.

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -8,10 +8,42 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rpuneet/mycel/pkg/home"
 	"github.com/rpuneet/mycel/pkg/provider"
 )
+
+// TestNewBackendProbeTimeout ensures a wedged Docker CLI cannot block mycel
+// boot: NewBackend must fail within dockerProbeTimeout (+ small slack).
+func TestNewBackendProbeTimeout(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "docker")
+	// Shell wrapper + long sleep: mirrors Docker CLI hanging on a wedged
+	// daemon. Process-group SIGKILL must reap both the shell and sleep.
+	script := "#!/bin/sh\ntrap '' TERM INT\nsleep 120\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+"/usr/bin:/bin")
+
+	start := time.Now()
+	_, err := NewBackend(Config{}, "mycel-", t.TempDir(), provider.DefaultRegistry)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("NewBackend succeeded against hanging docker stub; want timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error = %v, want timed out", err)
+	}
+	// Bound: probe timeout + WaitDelay kill slack. Far below the stub's 120s sleep.
+	if elapsed > dockerProbeTimeout+2*time.Second {
+		t.Fatalf("NewBackend took %v, want <= %v", elapsed, dockerProbeTimeout+2*time.Second)
+	}
+	if elapsed < dockerProbeTimeout/2 {
+		t.Fatalf("NewBackend returned too fast (%v); stub may not have been used", elapsed)
+	}
+}
 
 func TestConfigFromHome_Defaults(t *testing.T) {
 	cfg := ConfigFromHome(home.DockerRuntimeConfig{})

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -22,7 +22,8 @@ func TestNewBackendProbeTimeout(t *testing.T) {
 	// Shell wrapper + long sleep: mirrors Docker CLI hanging on a wedged
 	// daemon. Process-group SIGKILL must reap both the shell and sleep.
 	script := "#!/bin/sh\ntrap '' TERM INT\nsleep 120\n"
-	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+	// 0755: stub must be executable on PATH; test-only file in TempDir.
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil { //nolint:gosec // G306: executable stub requires +x
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+"/usr/bin:/bin")

--- a/pkg/container/docker_probe_unix.go
+++ b/pkg/container/docker_probe_unix.go
@@ -1,0 +1,63 @@
+//go:build unix
+
+package container
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// probeDockerCmd builds a `docker <args…>` command that cannot outlive
+// parent+dockerProbeTimeout. CommandContext alone is not enough for a
+// wedged Docker Desktop: the CLI can ignore SIGTERM (or leave child
+// sleepers under a shell wrapper), and Wait then blocks on pipes forever.
+// We put the probe in its own process group, SIGKILL the group when the
+// deadline hits, and set WaitDelay so Wait cannot outlive the kill by
+// more than a beat.
+func probeDockerCmd(parent context.Context, args ...string) (*exec.Cmd, context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(parent, dockerProbeTimeout)
+	cmd := exec.CommandContext(ctx, "docker", args...) //nolint:gosec // trusted binary + fixed args
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		// Negative pid = process group (Setpgid above).
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = time.Second
+	return cmd, ctx, cancel
+}
+
+// probeDocker runs a short `docker <args…>` discarding output.
+func probeDocker(parent context.Context, args ...string) error {
+	cmd, ctx, cancel := probeDockerCmd(parent, args...)
+	defer cancel()
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("docker daemon not available: probe timed out after %s: %w", dockerProbeTimeout, err)
+		}
+		return fmt.Errorf("docker daemon not available: %w", err)
+	}
+	return nil
+}
+
+// probeDockerOutput is probeDocker that returns stdout.
+func probeDockerOutput(parent context.Context, args ...string) ([]byte, error) {
+	cmd, _, cancel := probeDockerCmd(parent, args...)
+	defer cancel()
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return stdout.Bytes(), nil
+}

--- a/pkg/container/docker_probe_windows.go
+++ b/pkg/container/docker_probe_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package container
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"time"
+)
+
+// Windows lacks process-group SIGKILL; bound probes with Context + WaitDelay.
+func probeDockerCmd(parent context.Context, args ...string) (*exec.Cmd, context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(parent, dockerProbeTimeout)
+	cmd := exec.CommandContext(ctx, "docker", args...) //nolint:gosec // trusted binary + fixed args
+	cmd.WaitDelay = time.Second
+	return cmd, ctx, cancel
+}
+
+func probeDocker(parent context.Context, args ...string) error {
+	cmd, ctx, cancel := probeDockerCmd(parent, args...)
+	defer cancel()
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("docker daemon not available: probe timed out after %s: %w", dockerProbeTimeout, err)
+		}
+		return fmt.Errorf("docker daemon not available: %w", err)
+	}
+	return nil
+}
+
+func probeDockerOutput(parent context.Context, args ...string) ([]byte, error) {
+	cmd, _, cancel := probeDockerCmd(parent, args...)
+	defer cancel()
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return stdout.Bytes(), nil
+}

--- a/pkg/envpath/envpath.go
+++ b/pkg/envpath/envpath.go
@@ -1,0 +1,108 @@
+// Package envpath makes GUI-launched mycel processes find Homebrew (and
+// other well-known) binaries the same way an interactive shell would.
+//
+// macOS .app bundles and some launchd/desktop contexts inherit a minimal
+// PATH that omits /opt/homebrew/bin. Without enrichment, LookPath("tmux")
+// fails even when tmux is installed, and the UI reports "no runtime
+// backend" — a false dependency failure.
+package envpath
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+var enrichOnce sync.Once
+
+// ExtraBinDirs returns platform directories that commonly hold user-installed
+// CLIs (Homebrew, /usr/local, ~/.local). Only existing directories are
+// returned so PATH stays free of dead entries.
+func ExtraBinDirs() []string {
+	var candidates []string
+	switch runtime.GOOS {
+	case "darwin":
+		candidates = []string{
+			"/opt/homebrew/bin", // Apple Silicon Homebrew
+			"/opt/homebrew/sbin",
+			"/usr/local/bin", // Intel Homebrew / manual installs
+			"/usr/local/sbin",
+		}
+	case "linux":
+		candidates = []string{
+			"/home/linuxbrew/.linuxbrew/bin",
+			"/usr/local/bin",
+			"/usr/local/sbin",
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		candidates = append(candidates,
+			filepath.Join(home, ".local", "bin"),
+			filepath.Join(home, "bin"),
+			filepath.Join(home, "go", "bin"),
+		)
+	}
+
+	out := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, d := range candidates {
+		if d == "" {
+			continue
+		}
+		if _, ok := seen[d]; ok {
+			continue
+		}
+		seen[d] = struct{}{}
+		if fi, err := os.Stat(d); err == nil && fi.IsDir() {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// Merge prepends missing ExtraBinDirs entries onto path (PATH-shaped).
+// Existing entries keep their relative order; extras that are already
+// present are not duplicated. Pure — does not touch the process env.
+func Merge(path string) string {
+	extras := ExtraBinDirs()
+	if len(extras) == 0 {
+		return path
+	}
+	parts := filepath.SplitList(path)
+	have := make(map[string]struct{}, len(parts)+len(extras))
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		have[p] = struct{}{}
+	}
+	prefix := make([]string, 0, len(extras))
+	for _, d := range extras {
+		if _, ok := have[d]; ok {
+			continue
+		}
+		prefix = append(prefix, d)
+		have[d] = struct{}{}
+	}
+	if len(prefix) == 0 {
+		return path
+	}
+	if path == "" {
+		return strings.Join(prefix, string(os.PathListSeparator))
+	}
+	return strings.Join(prefix, string(os.PathListSeparator)) + string(os.PathListSeparator) + path
+}
+
+// Enrich once prepends well-known bin directories onto the process PATH.
+// Safe to call from multiple entrypoints (CLI, desktop); subsequent
+// calls are no-ops.
+func Enrich() {
+	enrichOnce.Do(func() {
+		merged := Merge(os.Getenv("PATH"))
+		if merged != os.Getenv("PATH") {
+			_ = os.Setenv("PATH", merged)
+		}
+	})
+}

--- a/pkg/envpath/envpath_test.go
+++ b/pkg/envpath/envpath_test.go
@@ -11,7 +11,7 @@ import (
 func TestMergePrependsMissingDirs(t *testing.T) {
 	dir := t.TempDir()
 	extra := filepath.Join(dir, "bin")
-	if err := os.Mkdir(extra, 0o755); err != nil {
+	if err := os.Mkdir(extra, 0o750); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/envpath/envpath_test.go
+++ b/pkg/envpath/envpath_test.go
@@ -1,0 +1,134 @@
+package envpath
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestMergePrependsMissingDirs(t *testing.T) {
+	dir := t.TempDir()
+	extra := filepath.Join(dir, "bin")
+	if err := os.Mkdir(extra, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Force ExtraBinDirs to see our temp dir by temporarily swapping HOME
+	// on platforms that include ~/.local/bin — and also verify Merge
+	// itself when given a PATH that already omits a known existing dir.
+	origPath := os.Getenv("PATH")
+	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
+
+	merged := Merge("/usr/bin:/bin")
+	if merged == "/usr/bin:/bin" && len(ExtraBinDirs()) == 0 {
+		t.Skip("no extra bin dirs exist on this host")
+	}
+	if !strings.Contains(merged, "/usr/bin") {
+		t.Fatalf("Merge dropped original PATH entries: %q", merged)
+	}
+	// First segment should be an extra (when any exist and were missing).
+	extras := ExtraBinDirs()
+	if len(extras) == 0 {
+		return
+	}
+	wantFirst := extras[0]
+	if _, already := pathSet(origPath)[wantFirst]; already {
+		// Host PATH already has Homebrew — Merge should be a no-op for that entry.
+		if !strings.Contains(merged, wantFirst) {
+			t.Fatalf("Merge lost existing extra %q in %q", wantFirst, merged)
+		}
+		return
+	}
+	first, _, _ := strings.Cut(merged, string(os.PathListSeparator))
+	if first != wantFirst {
+		t.Fatalf("Merge first entry = %q, want %q (full=%q)", first, wantFirst, merged)
+	}
+}
+
+func TestMergeIdempotentForPresentDirs(t *testing.T) {
+	extras := ExtraBinDirs()
+	if len(extras) == 0 {
+		t.Skip("no extra bin dirs on this host")
+	}
+	base := strings.Join(extras, string(os.PathListSeparator)) + string(os.PathListSeparator) + "/usr/bin"
+	got := Merge(base)
+	if got != base {
+		t.Fatalf("Merge rewrote PATH that already had extras:\n got %q\nwant %q", got, base)
+	}
+}
+
+func TestMergeEmptyPath(t *testing.T) {
+	extras := ExtraBinDirs()
+	if len(extras) == 0 {
+		t.Skip("no extra bin dirs on this host")
+	}
+	got := Merge("")
+	if got != strings.Join(extras, string(os.PathListSeparator)) {
+		t.Fatalf("Merge(\"\") = %q, want joined extras", got)
+	}
+}
+
+func TestExtraBinDirsOnlyExisting(t *testing.T) {
+	for _, d := range ExtraBinDirs() {
+		fi, err := os.Stat(d)
+		if err != nil || !fi.IsDir() {
+			t.Fatalf("ExtraBinDirs returned non-dir %q: %v", d, err)
+		}
+	}
+}
+
+func TestEnrichSetsProcessPATH(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("enrich targets unix desktop/CLI hosts")
+	}
+	extras := ExtraBinDirs()
+	if len(extras) == 0 {
+		t.Skip("no extra bin dirs on this host")
+	}
+
+	orig := os.Getenv("PATH")
+	t.Cleanup(func() { _ = os.Setenv("PATH", orig) })
+
+	// Strip extras so Enrich has work to do. enrichOnce may already have
+	// fired in this process — call Merge directly for the assertion and
+	// Enrich for the side-effect smoke check.
+	stripped := stripDirs(orig, extras)
+	_ = os.Setenv("PATH", stripped)
+	merged := Merge(stripped)
+	for _, d := range extras {
+		if !strings.Contains(merged, d) {
+			t.Fatalf("Merge missing %q in %q", d, merged)
+		}
+	}
+	Enrich()
+	if got := os.Getenv("PATH"); got == "" {
+		t.Fatal("Enrich left PATH empty")
+	}
+}
+
+func pathSet(path string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, p := range filepath.SplitList(path) {
+		if p != "" {
+			out[p] = struct{}{}
+		}
+	}
+	return out
+}
+
+func stripDirs(path string, drop []string) string {
+	dropSet := pathSet(strings.Join(drop, string(os.PathListSeparator)))
+	keep := make([]string, 0)
+	for _, p := range filepath.SplitList(path) {
+		if p == "" {
+			continue
+		}
+		if _, bad := dropSet[p]; bad {
+			continue
+		}
+		keep = append(keep, p)
+	}
+	return strings.Join(keep, string(os.PathListSeparator))
+}


### PR DESCRIPTION
## Summary
- **`pkg/envpath`**: at `cmd/mycel` and `desktop` entry, prepend Homebrew / `/usr/local` / `~/.local/bin` so GUI-launched processes find `tmux` and other CLIs (root cause of desktop “tmux not found / No runtime backend” when tmux is installed).
- **`pkg/container`**: Docker `info` / session inspect-exec probes use a 3s deadline + process-group SIGKILL + WaitDelay so wedged Docker Desktop cannot hang boot; timeout ⇒ Docker unavailable ⇒ tmux fallback.

Part of #3624 §1c.

## Test plan
- [x] `go test ./pkg/envpath/ -count=1`
- [x] `go test ./pkg/container/ -count=1 -run Probe` (~3s timeout test)
- [ ] Rebuild desktop `.app` and confirm Dock launch finds tmux without PATH hacks
- [ ] With Docker wedged/stopped, daemon still boots on tmux


Made with [Cursor](https://cursor.com)