### PR TITLE
fix(web): Home stream avatar-only attribution + density polish

### DIFF
--- a/web/src/components/agent-ui/AgentChip.tsx
+++ b/web/src/components/agent-ui/AgentChip.tsx
@@ -28,6 +28,10 @@ export interface AgentChipProps {
   size?: number;
   /** Hide the status dot (e.g. sender chips in message feeds). */
   showDot?: boolean;
+  /** Show the mono agent name next to the character (default true). Set
+   *  false for dense streams where the name is redundant — hover/title
+   *  and aria-label still expose identity. */
+  showName?: boolean;
   className?: string;
   onClick?: () => void;
   /** Show a hover popover (state, task, provider, spend) on mouse-over. */
@@ -46,6 +50,7 @@ export const AgentChip = memo(function AgentChip({
   state,
   size = 18,
   showDot = true,
+  showName = true,
   className = "",
   onClick,
   preview = false,
@@ -93,15 +98,18 @@ export const AgentChip = memo(function AgentChip({
         onBlur: closePreview,
       }
     : {};
+  const label = state ? `${name} (${state})` : name;
   const body = (
     <>
       <LiveAgentCharacter name={name} state={state ?? "idle"} size={size} />
-      <span
-        className="truncate font-mono"
-        style={{ fontSize: Math.max(11, Math.min(13, size * 0.68)) }}
-      >
-        {name}
-      </span>
+      {showName && (
+        <span
+          className="truncate font-mono"
+          style={{ fontSize: Math.max(11, Math.min(13, size * 0.68)) }}
+        >
+          {name}
+        </span>
+      )}
       {showDot && state !== undefined && (
         <span
           data-testid="agent-chip-dot"
@@ -113,7 +121,7 @@ export const AgentChip = memo(function AgentChip({
       )}
     </>
   );
-  const cls = `inline-flex items-center gap-1.5 min-w-0 ${className}`.trim();
+  const cls = `inline-flex items-center ${showName ? "gap-1.5" : "gap-0"} min-w-0 ${className}`.trim();
   const card = preview && hoverRect && (
     <AgentHoverCard name={name} rect={hoverRect} seed={previewSeed} />
   );
@@ -126,6 +134,7 @@ export const AgentChip = memo(function AgentChip({
           onClick={onClick}
           className={cls}
           title={name}
+          aria-label={label}
           {...previewHandlers}
         >
           {body}
@@ -136,7 +145,13 @@ export const AgentChip = memo(function AgentChip({
   }
   return (
     <>
-      <span ref={anchorRef as React.RefObject<HTMLSpanElement>} className={cls} title={name} {...previewHandlers}>
+      <span
+        ref={anchorRef as React.RefObject<HTMLSpanElement>}
+        className={cls}
+        title={name}
+        aria-label={label}
+        {...previewHandlers}
+      >
         {body}
       </span>
       {card}

--- a/web/src/components/agent-ui/__tests__/character.test.tsx
+++ b/web/src/components/agent-ui/__tests__/character.test.tsx
@@ -135,6 +135,12 @@ describe("AgentChip", () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it("hides the mono name when showName is false but keeps accessible label", () => {
+    render(<AgentChip name="lucid-meerkat" state="working" showName={false} />);
+    expect(screen.queryByText("lucid-meerkat")).toBeNull();
+    expect(screen.getByLabelText("lucid-meerkat (working)")).toBeInTheDocument();
+  });
+
   it("does not render a hover card without the preview prop", () => {
     render(<AgentChip name="lucid-meerkat" state="idle" />);
     expect(screen.queryByTestId("agent-hover-card")).toBeNull();

--- a/web/src/views/Home.tsx
+++ b/web/src/views/Home.tsx
@@ -520,11 +520,20 @@ export function Home() {
           Single column on mobile; the rail drops below the stream. */}
       <div className="flex-1 min-h-0 grid grid-cols-1 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] gap-3">
         {/* Agents live stream — the centerpiece, unchanged behavior. */}
-        <div className="min-h-0 flex flex-col rounded-lg border border-mycel-border bg-mycel-surface overflow-hidden relative">
+        <div className="min-h-0 flex flex-col rounded-lg border border-mycel-border bg-mycel-surface shadow-mycel-sm overflow-hidden relative">
           <div className="shrink-0 flex items-center gap-2 px-3 py-1.5 border-b border-mycel-border bg-mycel-bg">
-            <span className="text-[10px] font-semibold text-mycel-muted uppercase tracking-widest">
+            <span className="text-[10px] font-semibold text-mycel-muted uppercase tracking-widest shrink-0">
               Agents live
             </span>
+            {sorted.length > 0 && (
+              <span
+                className="text-[10px] font-mono tabular-nums text-mycel-muted"
+                data-testid="home-stream-agent-count"
+                title={`${sorted.length} agent${sorted.length === 1 ? "" : "s"} in this view`}
+              >
+                {sorted.length}
+              </span>
+            )}
             <div
               className="inline-flex items-center rounded-md border border-mycel-border bg-mycel-surface p-0.5"
               role="group"
@@ -558,7 +567,7 @@ export function Home() {
                 By agent
               </button>
             </div>
-            <span className="ml-auto">
+            <span className="ml-auto min-w-0">
               <SystemPulse />
             </span>
           </div>

--- a/web/src/views/home/ChronologicalStream.tsx
+++ b/web/src/views/home/ChronologicalStream.tsx
@@ -3,19 +3,22 @@
  *
  * Flattens tool/lifecycle nodes from every visible agent into one
  * newest-first timeline. Running rows pin to the top (same pattern as
- * AgentCard). Each row is attributed to its agent via a compact name
- * chip that opens the Home drill-down.
+ * AgentCard). Attribution is an avatar-only AgentChip (hover card like
+ * the agents dropdown) so the stream stays dense when one agent dominates.
  */
 
 import { useMemo } from "react";
 import type { AgentActivity, FilterType, ToolNode } from "../../components/live/liveTypes";
 import { flattenNodes, nodeMatchesSearch, partitionRunning } from "../../components/live/liveHelpers";
 import { EventRow } from "../../components/live/EventRow";
-import { StateDot } from "../../components/live/LiveRenderers";
 import { EmptyState } from "../../components/EmptyState";
+import { AgentChip } from "../../components/agent-ui";
 
 /** Cap on completed rows in the Home stream — full history lives on agent detail. */
 export const HOME_STREAM_MAX_ROWS = 80;
+
+/** Fixed column width for the avatar rail — keeps event text aligned. */
+const AVATAR_COL = "w-9";
 
 export interface StreamEntry {
   agentName: string;
@@ -55,54 +58,72 @@ function buildEntries(
   return out.sort((x, y) => y.node.startTime - x.node.startTime);
 }
 
-function StreamAgentChip({
-  name,
-  state,
-  onOpen,
-}: {
-  name: string;
-  state: string;
-  onOpen: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onOpen}
-      title={`Open ${name} detail view`}
-      className="shrink-0 inline-flex items-center gap-1.5 max-w-[7.5rem] px-2 py-0.5 rounded-md border border-mycel-border bg-mycel-bg text-[11px] font-medium text-mycel-text hover:border-mycel-accent hover:text-mycel-accent transition-colors"
-    >
-      <StateDot state={state} />
-      <span className="truncate">{name}</span>
-    </button>
-  );
-}
-
 function AttributedEventRow({
   entry,
   searchTerm,
   onOpenAgent,
+  showAvatar,
 }: {
   entry: StreamEntry;
   searchTerm: string;
   onOpenAgent: (name: string) => void;
+  /** False when the previous row is the same agent — keeps a quiet rail. */
+  showAvatar: boolean;
 }) {
   return (
     <div
-      className="flex items-stretch border-b border-mycel-border last:border-b-0"
+      className="flex items-stretch border-b border-mycel-border/70 last:border-b-0 hover:bg-mycel-surface-hover/40 transition-colors"
       data-testid="home-stream-row"
       data-agent={entry.agentName}
     >
-      <div className="flex items-center pl-2.5 pr-1 shrink-0">
-        <StreamAgentChip
-          name={entry.agentName}
-          state={entry.agentState}
-          onOpen={() => onOpenAgent(entry.agentName)}
-        />
+      <div className={`flex items-center justify-center shrink-0 ${AVATAR_COL} py-1`}>
+        {showAvatar ? (
+          <AgentChip
+            name={entry.agentName}
+            state={entry.agentState}
+            size={22}
+            showName={false}
+            showDot={false}
+            preview
+            onClick={() => onOpenAgent(entry.agentName)}
+            className="rounded-md p-0.5 hover:bg-mycel-accent-subtle/50 transition-colors"
+          />
+        ) : (
+          <span
+            className="block w-0.5 h-3 rounded-full bg-mycel-border"
+            aria-hidden
+            title={entry.agentName}
+          />
+        )}
       </div>
-      <div className="flex-1 min-w-0 [&_>div]:border-b-0">
+      <div className="flex-1 min-w-0 [&_>div]:border-b-0 [&_button]:py-1 [&_button]:pl-1.5 [&_button]:pr-2.5 [&_button]:gap-2">
         <EventRow node={entry.node} searchQuery={searchTerm} />
       </div>
     </div>
+  );
+}
+
+function StreamBlock({
+  entries,
+  searchTerm,
+  onOpenAgent,
+}: {
+  entries: StreamEntry[];
+  searchTerm: string;
+  onOpenAgent: (name: string) => void;
+}) {
+  return (
+    <>
+      {entries.map((entry, i) => (
+        <AttributedEventRow
+          key={`${entry.agentName}:${entry.node.id}`}
+          entry={entry}
+          searchTerm={searchTerm}
+          onOpenAgent={onOpenAgent}
+          showAvatar={i === 0 || entries[i - 1]!.agentName !== entry.agentName}
+        />
+      ))}
+    </>
   );
 }
 
@@ -149,11 +170,11 @@ export function ChronologicalStream({
   return (
     <div data-testid="home-chronological-stream" className="flex flex-col min-h-0">
       {running.length > 0 && (
-        <div className="bg-mycel-accent-subtle/30 border-b-2 border-mycel-accent-subtle">
-          <div className="flex items-center gap-2 px-3 py-1 bg-mycel-surface/95 border-b border-mycel-border">
-            <span className="relative flex h-2 w-2 shrink-0" aria-hidden>
+        <div className="bg-mycel-accent-subtle/25 border-b border-mycel-accent-subtle/60">
+          <div className="flex items-center gap-2 px-2.5 py-1 bg-mycel-surface/90 border-b border-mycel-border/80">
+            <span className="relative flex h-1.5 w-1.5 shrink-0" aria-hidden>
               <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-mycel-accent opacity-60 motion-reduce:hidden" />
-              <span className="relative inline-flex h-2 w-2 rounded-full bg-mycel-accent" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-mycel-accent" />
             </span>
             <span className="text-[10px] uppercase tracking-wide font-semibold text-mycel-accent">
               Running
@@ -162,26 +183,12 @@ export function ChronologicalStream({
               {running.length}
             </span>
           </div>
-          {running.map((entry) => (
-            <AttributedEventRow
-              key={`run-${entry.agentName}:${entry.node.id}`}
-              entry={entry}
-              searchTerm={searchTerm}
-              onOpenAgent={onOpenAgent}
-            />
-          ))}
+          <StreamBlock entries={running} searchTerm={searchTerm} onOpenAgent={onOpenAgent} />
         </div>
       )}
-      {shown.map((entry) => (
-        <AttributedEventRow
-          key={`${entry.agentName}:${entry.node.id}`}
-          entry={entry}
-          searchTerm={searchTerm}
-          onOpenAgent={onOpenAgent}
-        />
-      ))}
+      <StreamBlock entries={shown} searchTerm={searchTerm} onOpenAgent={onOpenAgent} />
       {hiddenCount > 0 && (
-        <div className="px-3 py-2 text-[11px] text-mycel-muted font-mono text-center border-t border-mycel-border">
+        <div className="px-3 py-1.5 text-[11px] text-mycel-muted font-mono text-center border-t border-mycel-border">
           {hiddenCount} older event{hiddenCount === 1 ? "" : "s"} hidden — open an agent for full history
         </div>
       )}

--- a/web/src/views/home/OverviewStrip.tsx
+++ b/web/src/views/home/OverviewStrip.tsx
@@ -87,7 +87,7 @@ function Cell({
       </span>
     </>
   );
-  const cls = "block bg-mycel-surface px-3 py-2 min-w-0 transition-colors";
+  const cls = "block bg-mycel-surface px-3 py-1.5 min-w-0 transition-colors";
   return to ? (
     <Link to={to} data-testid={testId} className={`${cls} hover:bg-mycel-surface-hover`}>
       {body}

--- a/web/src/views/home/SystemPulse.tsx
+++ b/web/src/views/home/SystemPulse.tsx
@@ -13,11 +13,22 @@ import { usePolling } from "../../hooks/usePolling";
 
 const gb = (b: number) => `${(b / 1024 ** 3).toFixed(1)}G`;
 
-function Chip({ label, value, warn }: { label: string; value: string; warn?: boolean }) {
+function Chip({
+  label,
+  value,
+  warn,
+  title,
+}: {
+  label: string;
+  value: string;
+  warn?: boolean;
+  /** Override hover detail (e.g. absolute MEM when chip shows %). */
+  title?: string;
+}) {
   return (
     <span
       className="inline-flex items-baseline gap-1 rounded-md border border-mycel-border bg-mycel-surface px-1.5 py-0.5"
-      title={`${label}: ${value}`}
+      title={title ?? `${label}: ${value}`}
     >
       <span className="text-[9px] uppercase tracking-wide text-mycel-muted">{label}</span>
       <span className={`text-[11px] font-mono tabular-nums ${warn ? "text-mycel-warning" : "text-mycel-text"}`}>
@@ -47,8 +58,9 @@ export function SystemPulse() {
           <Chip label="CPU" value={`${data.cpu_usage_percent.toFixed(0)}%`} warn={data.cpu_usage_percent >= 85} />
           <Chip
             label="MEM"
-            value={`${gb(data.memory_used_bytes)}/${gb(data.memory_total_bytes)}`}
+            value={`${data.memory_usage_percent.toFixed(0)}%`}
             warn={data.memory_usage_percent >= 90}
+            title={`MEM: ${gb(data.memory_used_bytes)} / ${gb(data.memory_total_bytes)} (${data.memory_usage_percent.toFixed(0)}%)`}
           />
           <Chip label="DISK" value={`${data.disk_usage_percent.toFixed(0)}%`} warn={data.disk_usage_percent >= 90} />
         </>

--- a/web/src/views/home/__tests__/chronologicalStream.test.tsx
+++ b/web/src/views/home/__tests__/chronologicalStream.test.tsx
@@ -37,7 +37,7 @@ function agent(name: string, nodes: ToolNode[], state = "working"): AgentActivit
 }
 
 describe("ChronologicalStream", () => {
-  it("merges agents newest-first with agent chips", () => {
+  it("merges agents newest-first with avatar-only chips (no name text)", () => {
     const onOpen = vi.fn();
     render(
       <ChronologicalStream
@@ -58,8 +58,35 @@ describe("ChronologicalStream", () => {
     expect(rows[0]!.getAttribute("data-agent")).toBe("bob");
     expect(rows[1]!.getAttribute("data-agent")).toBe("alice");
 
-    fireEvent.click(screen.getByTitle("Open bob detail view"));
+    // Avatar-only: name is not rendered as text; identity is title/aria + hover.
+    expect(screen.queryByText("bob")).toBeNull();
+    expect(screen.queryByText("alice")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /bob/ }));
     expect(onOpen).toHaveBeenCalledWith("bob");
+  });
+
+  it("collapses consecutive same-agent avatars into a quiet rail", () => {
+    render(
+      <ChronologicalStream
+        agents={[
+          agent("alice", [
+            node({ id: "a2", startTime: 200, args: "second" }),
+            node({ id: "a1", startTime: 100, args: "first" }),
+          ]),
+        ]}
+        searchTerm=""
+        typeFilter="all"
+        onOpenAgent={() => {}}
+        emptyTitle="empty"
+        emptyDescription="none"
+      />,
+    );
+
+    const rows = screen.getAllByTestId("home-stream-row");
+    expect(rows).toHaveLength(2);
+    // First row (newest) shows the avatar chip; the next same-agent row does not.
+    expect(rows[0]!.querySelector('[aria-label*="alice"]')).toBeTruthy();
+    expect(rows[1]!.querySelector('[aria-label*="alice"]')).toBeNull();
   });
 
   it("pins running rows above completed ones", () => {


### PR DESCRIPTION
## Summary
- **Agents live** stream: replace repeated agent-name pills with avatar-only `AgentChip` (hover card like the agents dropdown); collapse consecutive same-agent avatars into a quiet rail
- **Host MEM**: show `%` in the chip (fixes truncation); absolute GB on hover title
- **Density**: tighter stream rows, OverviewStrip padding, agent count in stream header

Part of #3624

## Test plan
- [x] Unit: chronologicalStream + AgentChip showName=false + homeModules
- [ ] Home As it comes: avatar-only, hover card, click opens drill-down
- [ ] Consecutive same-agent rows collapse avatar
- [ ] Host MEM % visible; hover shows GB
- [ ] By agent view unchanged