### PR TITLE
fix(agent): resume session on stop/start + remove duplicate Back (#3713, #3716)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1296,9 +1296,19 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 		sessionID = opts.SessionID
 		existing.SessionID = sessionID
 	}
-	// Resume if a session ID exists (auto-continue previous session)
-	isRealSessionID := len(sessionID) == 36 && sessionID[8] == '-'
-	resume := isRealSessionID
+	// Cursor often never wrote session_id onto the agent row before #3713;
+	// recover it from usage.jsonl so --resume <id> still fires on restart.
+	if sessionID == "" {
+		if id := provider.LatestCursorSessionID(m.agentsRoot(), name); id != "" {
+			sessionID = id
+			existing.SessionID = id
+		}
+	}
+	// Resume when we have a provider-safe session id, or (below) when the
+	// worktree has a prior session for bare --continue / --resume.
+	// Cursor chat ids are UUIDs; Claude/agy use the same shape. Non-UUID
+	// ids that still pass SafeSessionID (e.g. pi) also count.
+	resume := provider.SafeSessionID(sessionID)
 
 	// Check if existing worktree can be reused for resume (tmux only).
 	// Existing agents keep working from their stored WorktreeDir (which
@@ -1913,6 +1923,13 @@ func (m *Manager) captureSessionIDForAgent(ctx context.Context, ag *Agent, rt ru
 	// where the UUID IS the session ID.
 	if id := findSessionIDFromTranscripts(m.agentsRoot(), ag.Name); id != "" {
 		log.Debug("captured session ID from JSONL transcript", "agent", ag.Name, "session_id", id)
+		return id
+	}
+
+	// Cursor: usage.jsonl is written on every Stop hook and carries session_id
+	// even when the agent row never stored one (#3713).
+	if id := provider.LatestCursorSessionID(m.agentsRoot(), ag.Name); id != "" {
+		log.Debug("captured session ID from cursor usage", "agent", ag.Name, "session_id", id)
 		return id
 	}
 
@@ -2751,6 +2768,30 @@ func (m *Manager) UpdateAgentState(ctx context.Context, name string, state State
 	if changed {
 		m.notifyStateChange(name, state, task)
 	}
+	return nil
+}
+
+// SetAgentSessionID records the provider session id for later resume
+// (stop→start / restart). No-op when the id is unchanged or unsafe.
+func (m *Manager) SetAgentSessionID(ctx context.Context, name, sessionID string) error {
+	if !provider.SafeSessionID(sessionID) {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	agent, exists := m.agents[name]
+	if !exists {
+		return fmt.Errorf("agent %s: %w", name, ErrNotFound)
+	}
+	if agent.SessionID == sessionID {
+		return nil
+	}
+	agent.SessionID = sessionID
+	agent.UpdatedAt = time.Now()
+	if err := m.saveState(ctx); err != nil {
+		log.Warn("failed to save agent session_id", "error", err)
+	}
+	writeSessionIDFile(m.agentsRoot(), name, sessionID)
 	return nil
 }
 

--- a/pkg/agent/hook_ingest.go
+++ b/pkg/agent/hook_ingest.go
@@ -131,6 +131,15 @@ func (s *AgentService) IngestHookEvent(ctx context.Context, name string, payload
 		}
 	}
 
+	// Persist provider session_id whenever hooks report one so stop→start /
+	// restart can --resume the same chat (#3713). Cursor puts this on every
+	// payload; Claude/agy may include it on SessionStart / Stop.
+	if payload.SessionID != "" {
+		if err := s.manager.SetAgentSessionID(ctx, name, payload.SessionID); err != nil {
+			log.Debug("hook session_id update skipped", "agent", name, "error", err)
+		}
+	}
+
 	// Cursor (and any future provider that puts tokens on Stop) reports
 	// usage on the turn-complete hook rather than in a session transcript.
 	// Persist it where CostReader looks, or Insights stays at $0 forever.

--- a/pkg/agent/hook_ingest_test.go
+++ b/pkg/agent/hook_ingest_test.go
@@ -485,6 +485,10 @@ func TestIngestHookEvent_StopPersistsCursorUsage(t *testing.T) {
 		t.Fatalf("IngestHookEvent: %v", err)
 	}
 
+	if got := mgr.agents["cursor-agent"].SessionID; got != "sess" {
+		t.Errorf("SessionID = %q, want sess (persisted for resume #3713)", got)
+	}
+
 	path := filepath.Join(mgr.agentsRoot(), "cursor-agent", "session", "cursor", "usage.jsonl")
 	raw, err := os.ReadFile(path) //nolint:gosec // test path under the temp agents root
 	if err != nil {

--- a/pkg/agent/model_command_test.go
+++ b/pkg/agent/model_command_test.go
@@ -68,6 +68,32 @@ func TestGetAgentCommandModel(t *testing.T) {
 	}
 }
 
+// TestGetAgentCommand_CursorResume is the #3713 regression: stop→start must
+// pass --continue (or --resume <id>) so Cursor does not open a fresh chat.
+func TestGetAgentCommand_CursorResume(t *testing.T) {
+	m := &Manager{providerRegistry: provider.DefaultRegistry}
+	const sid = "ec4fb8e4-e6ee-4bf5-9e36-17a8c3ea122f"
+
+	cmd, ok := m.getAgentCommand("cursor", "fast-crane", true, "", "")
+	if !ok {
+		t.Fatal("getAgentCommand(cursor) not ok")
+	}
+	if !strings.Contains(cmd, "--continue") {
+		t.Errorf("resume without id missing --continue: %q", cmd)
+	}
+
+	cmd, ok = m.getAgentCommand("cursor", "fast-crane", true, sid, "")
+	if !ok {
+		t.Fatal("getAgentCommand(cursor+id) not ok")
+	}
+	if !strings.Contains(cmd, "--resume "+sid) {
+		t.Errorf("resume with id missing --resume: %q", cmd)
+	}
+	if strings.Contains(cmd, "--continue") {
+		t.Errorf("explicit id must not also pass --continue: %q", cmd)
+	}
+}
+
 // TestGetAgentCommandModelWithOverride verifies the global command
 // override path still injects a generic --model flag (gated on
 // SafeModelName) via appendSessionFlags.

--- a/pkg/provider/cursor.go
+++ b/pkg/provider/cursor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"regexp"
 )
 
 // CursorProvider implements the Provider interface for Cursor Agent.
@@ -64,16 +65,20 @@ func (p *CursorProvider) InstallHint() string {
 }
 
 // BuildCommand returns the full command for a given runtime context.
-// Supports --resume with session ID for session continuation, and
-// --model <m> for model selection. Both values are spliced into a shell
-// command line, so unsafe values are dropped.
+// Resume priority: SessionID (--resume <id>) > Resume flag (--continue).
+// cursor-agent accepts both; without either it starts a fresh chat.
+// Model and session values are spliced into a shell command line, so
+// unsafe values are dropped.
 func (p *CursorProvider) BuildCommand(opts CommandOpts) string {
 	cmd := p.command
 	if SafeModelName(opts.Model) {
 		cmd += " --model " + opts.Model
 	}
-	if SafeSessionID(opts.SessionID) {
+	switch {
+	case SafeSessionID(opts.SessionID):
 		cmd += " --resume " + opts.SessionID
+	case opts.Resume:
+		cmd += " --continue"
 	}
 	return cmd
 }
@@ -117,6 +122,32 @@ func (p *CursorProvider) Version(ctx context.Context) string {
 	return getBinaryVersion(ctx, p.binary, "--version")
 }
 
+// cursorResumePattern matches cursor-agent's resume hint in pane/log output.
+var cursorResumePattern = regexp.MustCompile(`(?:cursor-agent|agent)\s+--resume\s+([A-Za-z0-9._][A-Za-z0-9._-]*)`)
+
+// cursorSessionJSONPattern matches "session_id":"<id>" in hook/usage JSON lines.
+var cursorSessionJSONPattern = regexp.MustCompile(`"session_id"\s*:\s*"([A-Za-z0-9._][A-Za-z0-9._-]*)"`)
+
+// SupportsResume reports that Cursor Agent can resume a chat by ID or via --continue.
+func (p *CursorProvider) SupportsResume() bool { return true }
+
+// ParseSessionID extracts a Cursor chat/session ID from tool output or JSONL.
+func (p *CursorProvider) ParseSessionID(output string) string {
+	if m := cursorResumePattern.FindStringSubmatch(output); len(m) == 2 && SafeSessionID(m[1]) {
+		return m[1]
+	}
+	if m := cursorSessionJSONPattern.FindStringSubmatch(output); len(m) == 2 && SafeSessionID(m[1]) {
+		return m[1]
+	}
+	return ""
+}
+
+// HasResumableSession reports whether Cursor has a prior chat that --continue
+// can pick up. Cursor keys history by workspace; without a reliable on-disk
+// probe from the worktree alone we stay permissive (true) so restart still
+// attempts --continue. Prefer a stored SessionID when available.
+func (p *CursorProvider) HasResumableSession(_ string) bool { return true }
+
 // Ensure CursorProvider implements Provider interface.
 var _ Provider = (*CursorProvider)(nil)
 var _ ActivitySource = (*CursorProvider)(nil)
@@ -124,3 +155,5 @@ var _ ModelLister = (*CursorProvider)(nil)
 var _ MCPConfigReader = (*CursorProvider)(nil)
 var _ ContainerCustomizer = (*CursorProvider)(nil)
 var _ SessionCustomizer = (*CursorProvider)(nil)
+var _ SessionResumer = (*CursorProvider)(nil)
+var _ ResumableSessionDetector = (*CursorProvider)(nil)

--- a/pkg/provider/cursor_costs.go
+++ b/pkg/provider/cursor_costs.go
@@ -102,6 +102,28 @@ func cursorPricingFor(model string) ModelPricing {
 	return defaultCursorPricing
 }
 
+// LatestCursorSessionID returns the most recent non-empty session_id from
+// the agent's Cursor usage JSONL, or "" when none is available. Used on
+// stop/restart so mycel can pass --resume <id> after a Cursor session
+// (hooks write usage even when agent.session_id was never populated).
+func LatestCursorSessionID(agentsDir, agent string) string {
+	if agentsDir == "" || agent == "" {
+		return ""
+	}
+	path := filepath.Join(agentsDir, agent, CursorUsageRelDir, CursorUsageFile)
+	recs, err := readCursorUsageFile(path)
+	if err != nil || len(recs) == 0 {
+		return ""
+	}
+	for i := len(recs) - 1; i >= 0; i-- {
+		id := strings.TrimSpace(recs[i].SessionID)
+		if SafeSessionID(id) {
+			return id
+		}
+	}
+	return ""
+}
+
 // AppendCursorUsage writes one priced usage record for agent under
 // AgentsDir. Called from hook ingestion when a Stop payload carries
 // token counts. Empty AgentsDir or a record with no tokens is a no-op.

--- a/pkg/provider/cursor_resume_test.go
+++ b/pkg/provider/cursor_resume_test.go
@@ -1,0 +1,101 @@
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCursorBuildCommandResume(t *testing.T) {
+	p := NewCursorProvider()
+	tests := []struct {
+		name string
+		opts CommandOpts
+		want string
+	}{
+		{
+			name: "fresh start",
+			opts: CommandOpts{},
+			want: "cursor-agent --trust",
+		},
+		{
+			name: "continue previous",
+			opts: CommandOpts{Resume: true},
+			want: "cursor-agent --trust --continue",
+		},
+		{
+			name: "resume by id",
+			opts: CommandOpts{SessionID: "ec4fb8e4-e6ee-4bf5-9e36-17a8c3ea122f"},
+			want: "cursor-agent --trust --resume ec4fb8e4-e6ee-4bf5-9e36-17a8c3ea122f",
+		},
+		{
+			name: "session id wins over continue",
+			opts: CommandOpts{
+				SessionID: "ec4fb8e4-e6ee-4bf5-9e36-17a8c3ea122f",
+				Resume:    true,
+			},
+			want: "cursor-agent --trust --resume ec4fb8e4-e6ee-4bf5-9e36-17a8c3ea122f",
+		},
+		{
+			name: "unsafe session id dropped — continue still applies",
+			opts: CommandOpts{SessionID: "$(rm -rf /)", Resume: true},
+			want: "cursor-agent --trust --continue",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.BuildCommand(tt.opts)
+			if got != tt.want {
+				t.Errorf("BuildCommand() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCursorParseSessionID(t *testing.T) {
+	p := NewCursorProvider()
+	const id = "ec4fb8e4-e6ee-4bf5-9e36-17a8c3ea122f"
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{"resume hint", "agent --resume " + id + "\n", id},
+		{"json session_id", `{"session_id":"` + id + `","event":"Stop"}`, id},
+		{"empty", "no session here", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := p.ParseSessionID(tt.output); got != tt.want {
+				t.Errorf("ParseSessionID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+	if !p.SupportsResume() {
+		t.Error("SupportsResume() must be true")
+	}
+}
+
+func TestLatestCursorSessionID(t *testing.T) {
+	root := t.TempDir()
+	agent := "fast-crane"
+	dir := filepath.Join(root, agent, CursorUsageRelDir)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, CursorUsageFile)
+	body := `{"session_id":"old-sess","input_tokens":1,"output_tokens":1}
+{"session_id":"ec4fb8e4-e6ee-4bf5-9e36-17a8c3ea122f","input_tokens":2,"output_tokens":2}
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := LatestCursorSessionID(root, agent)
+	want := "ec4fb8e4-e6ee-4bf5-9e36-17a8c3ea122f"
+	if got != want {
+		t.Errorf("LatestCursorSessionID() = %q, want %q", got, want)
+	}
+	if LatestCursorSessionID(root, "missing") != "" {
+		t.Error("missing agent should return empty")
+	}
+}

--- a/pkg/provider/cursor_resume_test.go
+++ b/pkg/provider/cursor_resume_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestCursorBuildCommandResume(t *testing.T) {
 	p := NewCursorProvider()
-	tests := []struct {
+	tests := []struct { //nolint:govet // test table; field order matches literals
 		name string
-		opts CommandOpts
 		want string
+		opts CommandOpts
 	}{
 		{
 			name: "fresh start",

--- a/pkg/provider/pi.go
+++ b/pkg/provider/pi.go
@@ -139,10 +139,12 @@ func (p *PiProvider) BuildCommand(opts CommandOpts) string {
 			cmd += " --model " + opts.Model
 		}
 	}
-	if SafeSessionID(opts.SessionID) {
+	// Resume priority: SessionID (--session <id>) > Resume flag (--continue).
+	// Passing both confuses pi into treating the restart as a new turn.
+	switch {
+	case SafeSessionID(opts.SessionID):
 		cmd += " --session " + opts.SessionID
-	}
-	if opts.Resume {
+	case opts.Resume:
 		cmd += " --continue"
 	}
 	return cmd

--- a/pkg/provider/pi_test.go
+++ b/pkg/provider/pi_test.go
@@ -114,13 +114,13 @@ func TestPiBuildCommand(t *testing.T) {
 			want: piSpawnBase + " --continue",
 		},
 		{
-			name: "model + session + resume — all three flags",
+			name: "model + session + resume — session wins over --continue",
 			opts: CommandOpts{
 				Model:     "groq/llama-3.3-70b-versatile",
 				SessionID: "abc123",
 				Resume:    true,
 			},
-			want: piSpawnBase + " --provider groq --model llama-3.3-70b-versatile --session abc123 --continue",
+			want: piSpawnBase + " --provider groq --model llama-3.3-70b-versatile --session abc123",
 		},
 		{
 			name: "model with dots in model id",

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -1626,17 +1626,10 @@ export function AgentDetail() {
           // ── center slot: identity + status ──
           title: (
             <div className="flex items-center gap-3 min-w-0">
-              {/* ── Identity ── */}
-              <Link
-                to={agentsUrl}
-                className="text-mycel-muted hover:text-mycel-text transition-colors shrink-0"
-                title="Back to agents"
-                aria-label="Back to agents"
-              >
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M9 3l-4 4 4 4" />
-                </svg>
-              </Link>
+              {/* ── Identity ──
+                  Back/forward lives once in the header (HistoryNavButtons).
+                  Do not add a second chevron here — it duplicates the nav
+                  and sits awkwardly left of the avatar. */}
               <LiveAgentCharacter name={agent.name} state={agent.state} size={28} tool={agent.tool} />
               <span className="text-lg font-semibold text-mycel-text tracking-tight shrink-0">
                 {agent.name}


### PR DESCRIPTION
## Summary
- **Fixes #3713**: Stop→Start / Restart resumes the prior provider session for Cursor (and keeps Claude/pi resume paths consistent).
  - Cursor `BuildCommand` now passes `--continue` when `Resume` is set (and `--resume <id>` when a session id is known).
  - Hook ingestion persists `session_id` onto the agent row; stop/restart also recover it from `usage.jsonl`.
  - Pi no longer passes both `--session` and `--continue` when an id is present.
- **Fixes #3716**: Remove the duplicate Back chevron left of the agent avatar (header already has `HistoryNavButtons`).

Part of #3714.

## Test plan
- [x] `go test ./pkg/provider/ ./pkg/agent/`
- [ ] UI: open agent detail — only one Back control in the header
- [ ] Cursor dogfood: Stop → Start continues the same chat (not a fresh session)
- [ ] Restart continues the same chat
- [ ] Claude agent still resumes via `--resume` / `--continue` as before