### PR TITLE
fix(web): Create Agent Apps section → Notifications (#3647)

### DIFF
--- a/web/src/components/CreateAgentModal.tsx
+++ b/web/src/components/CreateAgentModal.tsx
@@ -120,8 +120,8 @@ export function CreateAgentModal({
   // ${secret:NAME} references resolved from the vault at spawn.
   const [envOpen, setEnvOpen] = useState(false);
   const [envRows, setEnvRows] = useState<EnvRow[]>([]);
-  // Apps — connected app channels this agent should listen to. The
-  // subscriptions are wired after the agent is created.
+  // Notifications — connected app channels this agent should listen to.
+  // Subscriptions are wired after the agent is created.
   const [appsOpen, setAppsOpen] = useState(false);
   const [appChannels, setAppChannels] = useState<Set<string>>(new Set());
   const [cloneFrom, setCloneFrom] = useState("");
@@ -1219,8 +1219,8 @@ export function CreateAgentModal({
                 {envOpen && <EnvVarsEditor rows={envRows} onChange={setEnvRows} />}
               </div>
 
-              {/* Apps — collapsible picker of connected app channels this
-                  agent should subscribe to. Wired after create succeeds. */}
+              {/* Notifications — collapsible picker of connected app channels
+                  this agent should subscribe to. Wired after create succeeds. */}
               <div className="flex flex-col gap-1.5" data-testid="create-agent-apps-section">
                 <button
                   type="button"
@@ -1238,7 +1238,7 @@ export function CreateAgentModal({
                   >
                     <path d="M2 0l4 4-4 4z" />
                   </svg>
-                  Apps{" "}
+                  Notifications{" "}
                   <span className="normal-case font-normal">
                     (optional{appChannels.size > 0 ? ` · ${appChannels.size} channel${appChannels.size === 1 ? "" : "s"}` : ""})
                   </span>

--- a/web/src/components/__tests__/CreateAgentModal.test.tsx
+++ b/web/src/components/__tests__/CreateAgentModal.test.tsx
@@ -89,8 +89,8 @@ describe("CreateAgentModal identity", () => {
   });
 });
 
-describe("CreateAgentModal apps step", () => {
-  it("renders the Apps section with connected app channels", async () => {
+describe("CreateAgentModal notifications step", () => {
+  it("renders the Notifications section with connected app channels", async () => {
     fetchMock.mockImplementation((url: RequestInfo | URL) => {
       const u = String(url);
       if (u.includes("/api/repos")) return jsonResponse({ repos: [], default: "/tmp/repo" });
@@ -106,12 +106,12 @@ describe("CreateAgentModal apps step", () => {
     });
     renderModal();
 
-    // The collapsed Apps section is present in the create flow.
+    // The collapsed Notifications section is present in the create flow.
     const section = screen.getByTestId("create-agent-apps-section");
     expect(section).toBeInTheDocument();
 
     // Expanding it lists the connected app's channels as checkboxes.
-    fireEvent.click(within(section).getByRole("button", { name: /Apps/ }));
+    fireEvent.click(within(section).getByRole("button", { name: /Notifications/ }));
     await waitFor(() => {
       expect(screen.getByTestId("agent-apps-picker")).toBeInTheDocument();
     });
@@ -141,7 +141,7 @@ describe("CreateAgentModal apps step", () => {
     renderModal();
 
     const section = screen.getByTestId("create-agent-apps-section");
-    fireEvent.click(within(section).getByRole("button", { name: /Apps/ }));
+    fireEvent.click(within(section).getByRole("button", { name: /Notifications/ }));
     await waitFor(() => {
       expect(within(section).getByText("general")).toBeInTheDocument();
     });

--- a/web/src/components/apps/AgentAppsPicker.tsx
+++ b/web/src/components/apps/AgentAppsPicker.tsx
@@ -1,10 +1,11 @@
 /**
- * AgentAppsPicker — the "Apps" section of the New Agent flow.
+ * AgentAppsPicker — the Notifications section of the New Agent flow.
  *
  * Lists the connected app instances (platform icon + status dot, same
  * visual system as the drawer tree) with their discovered channels as
  * checkboxes. The caller collects the selected channel keys and wires
- * the subscriptions after the agent is created.
+ * the subscriptions after the agent is created. The top-level /apps
+ * page (connected platforms) stays named Apps.
  */
 
 import { useEffect, useState } from "react";
@@ -57,7 +58,7 @@ export function AgentAppsPicker({
   if (instances === null) {
     return (
       <div className="text-xs text-mycel-muted px-1 py-2" data-testid="agent-apps-picker">
-        Loading apps…
+        Loading notification channels…
       </div>
     );
   }
@@ -68,8 +69,8 @@ export function AgentAppsPicker({
         className="text-xs text-mycel-muted bg-mycel-bg border border-mycel-border rounded-md px-3 py-2"
         data-testid="agent-apps-picker"
       >
-        No apps connected yet — connect Slack, Telegram, WhatsApp and more on the Apps page,
-        then wire their channels to agents here.
+        No platforms connected yet — connect Slack, Telegram, WhatsApp and more on the Apps page,
+        then subscribe this agent to their channels here.
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Renames the Create Agent collapsible section from **Apps** to **Notifications** so it matches agent detail Config.
- Clarifies empty-state copy: platforms live on the **Apps** page; this control is for channel subscriptions.
- Leaves the top-level `/apps` nav/page named Apps (connected platforms).

Part of #3647 (rename residual; picker already landed). Part of #3714.

## Test plan
- [x] Updated CreateAgentModal tests for Notifications label
- [ ] Open New Agent → expand Notifications → channels still list/select
- [ ] Agent detail Config still shows Notifications heading
- [ ] Sidebar Apps page unchanged