### PR TITLE
fix(apps): Gmail Sign in link + Advanced manual fields (#3722)

### DIFF
--- a/docs/explanation/apps.md
+++ b/docs/explanation/apps.md
@@ -130,12 +130,19 @@ clients permit.
 
 Gmail wires this flow (`pkg/gateway/gmail`) with the `gmail.readonly` +
 `gmail.send` scopes and `access_type=offline` + `prompt=consent` so Google
-always returns a refresh token. The server-side Google client is read from
-`GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET`. When they are unset,
-the plugin's optional `OAuthConfigured` capability reports `false`, so
-`oauth_available` is `false` and the connect UI shows the honest
-client-id/secret/refresh-token paste fallback instead of a button that would
-fail.
+always returns a refresh token. The connect UI **always** offers both
+**Sign in with Gmail** (browser link) and **Advanced** manual paste.
+
+Zero-paste Sign in uses the server Google client from
+`GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` (or release
+ldflags). When those are unset, paste Client ID + Client Secret under
+Advanced and click Sign in anyway — same loopback link, bring-your-own
+client — or paste a Refresh Token for the fully manual path. Gmail does
+**not** implement `OAuthConfigured`; hiding Sign in when the server
+client was missing is what made the link option disappear.
+
+Other OAuth plugins may still implement `OAuthConfigured` when a button
+would always fail with no user-supplied alternative:
 
 ```go
 // OAuthConfigured is an optional capability an OAuthFlow plugin implements to
@@ -161,7 +168,7 @@ type OAuthConfigured interface {
 4. Export the client on the machine running the daemon:
    `GOOGLE_OAUTH_CLIENT_ID=<id>.apps.googleusercontent.com` and
    `GOOGLE_OAUTH_CLIENT_SECRET=GOCSPX-…`, then restart `mycel up`. Gmail's
-   connect modal now shows one-click **Sign in with Gmail**.
+   connect modal **Sign in with Gmail** works with zero pasting.
 
 Slack-type apps that need a fixed HTTPS redirect stay on token paste; real
 Slack OAuth is deferred to a future hosted-redirect ("mycel cloud").

--- a/pkg/gateway/gmail/oauth.go
+++ b/pkg/gateway/gmail/oauth.go
@@ -14,11 +14,12 @@ import (
 )
 
 // Server-side Google "Desktop app" OAuth client. These are the
-// mycel-registered client credentials that make one-click "Connect with
-// Google" work; when neither source below is set, the connect UI falls back
-// to the manual client-id/secret/refresh-token paste.
+// mycel-registered client credentials that make zero-paste "Sign in with
+// Gmail" work. When neither source below is set, the connect UI still
+// offers Sign in — fill Client ID + Secret under Advanced (or paste a
+// full refresh token for the fully manual path).
 //
-// Resolution order:
+// Resolution order for the loopback consent flow:
 //  1. GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET environment
 //     variables — always wins, lets anyone override at runtime.
 //  2. defaultGoogleClientID / defaultGoogleClientSecret — empty in source
@@ -28,6 +29,8 @@ import (
 //     say the client secret is "not treated as confidential" — see
 //     https://developers.google.com/identity/protocols/oauth2#installed —
 //     so baking it into the binary is the standard, supported pattern.
+//  3. Per-instance vault secrets client_id / client_secret the user entered
+//     under Advanced before clicking Sign in.
 const (
 	envGoogleClientID     = "GOOGLE_OAUTH_CLIENT_ID"
 	envGoogleClientSecret = "GOOGLE_OAUTH_CLIENT_SECRET" //nolint:gosec // env var name, not a credential
@@ -40,9 +43,9 @@ const (
 //	-ldflags "-X 'github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientID=...' \
 //	          -X 'github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientSecret=...'"
 //
-// A local build with neither the env vars nor these ldflags set behaves
-// exactly as before: one-click sign-in reports unconfigured and the UI falls
-// back to the manual paste path.
+// A local build with neither the env vars nor these ldflags set still
+// offers Sign in with Gmail: paste a Desktop-app Client ID + Secret under
+// Advanced, then click Sign in (or paste a refresh token for fully manual).
 var (
 	defaultGoogleClientID     string //nolint:gochecknoglobals // ldflags injection target, empty by default
 	defaultGoogleClientSecret string //nolint:gochecknoglobals // ldflags injection target, empty by default
@@ -73,14 +76,20 @@ func newGoogleFlow() *oauth.LoopbackFlow {
 	)
 }
 
-// googleClientCreds resolves the server-side Google client — environment
-// variables first, then the build-time embedded default — returning an
-// actionable error (surfaced to the user) when neither is configured.
-func googleClientCreds(_ app.Instance) (clientID, clientSecret string, err error) {
+// googleClientCreds resolves the Google OAuth client — server env/ldflags
+// first, then per-instance Advanced fields — returning an actionable error
+// when none are available.
+func googleClientCreds(inst app.Instance) (clientID, clientSecret string, err error) {
 	clientID, clientSecret = resolveGoogleClientCreds()
+	if clientID == "" {
+		clientID = strings.TrimSpace(inst.OptionalSecret("client_id"))
+	}
+	if clientSecret == "" {
+		clientSecret = strings.TrimSpace(inst.OptionalSecret("client_secret"))
+	}
 	if clientID == "" || clientSecret == "" {
 		return "", "", fmt.Errorf(
-			"one-click Google sign-in is not configured on this server — set %s and %s to a Google \"Desktop app\" OAuth client, or paste an OAuth refresh token below instead",
+			"Google sign-in needs an OAuth client — set %s/%s on the server, or paste Client ID + Client Secret under Advanced and click Sign in again (or paste a Refresh Token for the fully manual path)",
 			envGoogleClientID, envGoogleClientSecret)
 	}
 	return clientID, clientSecret, nil

--- a/pkg/gateway/gmail/oauth_test.go
+++ b/pkg/gateway/gmail/oauth_test.go
@@ -15,63 +15,55 @@ func newTestPlugin() *plugin {
 }
 
 // TestPluginImplementsOAuth locks the capability assertions the server relies
-// on to dispatch the browser flow.
+// on to dispatch the browser flow. Gmail does not implement OAuthConfigured —
+// Sign in is always offered alongside Advanced manual paste.
 func TestPluginImplementsOAuth(t *testing.T) {
 	var p any = newTestPlugin()
 	if _, ok := p.(app.OAuthFlow); !ok {
 		t.Error("gmail plugin does not implement app.OAuthFlow")
 	}
-	if _, ok := p.(app.OAuthConfigured); !ok {
-		t.Error("gmail plugin does not implement app.OAuthConfigured")
+	if _, ok := p.(app.OAuthConfigured); ok {
+		t.Error("gmail plugin must not implement OAuthConfigured (always offer Sign in + Advanced)")
 	}
 }
 
-// TestOAuthConfiguredTracksEnv verifies one-click availability follows the
-// server-side Google client env vars.
-func TestOAuthConfiguredTracksEnv(t *testing.T) {
-	p := newTestPlugin()
-
+// TestGoogleConfiguredTracksEnv verifies server-side zero-paste availability
+// follows the Google client env vars (used by resolveGoogleClientCreds).
+func TestGoogleConfiguredTracksEnv(t *testing.T) {
 	t.Setenv(envGoogleClientID, "")
 	t.Setenv(envGoogleClientSecret, "")
-	if p.OAuthConfigured() {
-		t.Error("OAuthConfigured() = true with no client creds; want false")
+	if googleConfigured() {
+		t.Error("googleConfigured() = true with no client creds; want false")
 	}
 
 	t.Setenv(envGoogleClientID, "client.apps.googleusercontent.com")
 	t.Setenv(envGoogleClientSecret, "GOCSPX-secret")
-	if !p.OAuthConfigured() {
-		t.Error("OAuthConfigured() = false with client creds set; want true")
+	if !googleConfigured() {
+		t.Error("googleConfigured() = false with client creds set; want true")
 	}
 }
 
-// TestOAuthConfiguredTracksBuildDefault verifies one-click availability also
-// follows the ldflags-injected default* vars (simulated here by setting them
-// directly, since the real injection happens via `go build -ldflags -X` and
-// can't be exercised from within a test binary).
-func TestOAuthConfiguredTracksBuildDefault(t *testing.T) {
-	p := newTestPlugin()
-
+// TestGoogleConfiguredTracksBuildDefault verifies resolveGoogleClientCreds
+// also follows the ldflags-injected default* vars (simulated here by setting
+// them directly, since the real injection happens via `go build -ldflags -X`
+// and can't be exercised from within a test binary).
+func TestGoogleConfiguredTracksBuildDefault(t *testing.T) {
 	t.Setenv(envGoogleClientID, "")
 	t.Setenv(envGoogleClientSecret, "")
 
-	// Capture and restore the linker-injected defaults so a binary built with
-	// real embedded values isn't left cleared for later tests.
 	origID, origSecret := defaultGoogleClientID, defaultGoogleClientSecret
 	t.Cleanup(func() { defaultGoogleClientID, defaultGoogleClientSecret = origID, origSecret })
 
-	// Neither env nor build default set: unconfigured.
 	defaultGoogleClientID, defaultGoogleClientSecret = "", ""
-	if p.OAuthConfigured() {
-		t.Error("OAuthConfigured() = true with no creds at all; want false")
+	if googleConfigured() {
+		t.Error("googleConfigured() = true with no creds at all; want false")
 	}
 
-	// Build-time default set, no env override: configured, and the flow
-	// resolves to the injected default values.
 	defaultGoogleClientID = "default.apps.googleusercontent.com"
 	defaultGoogleClientSecret = "GOCSPX-default" //nolint:gosec // test fixture, not a real credential
 
-	if !p.OAuthConfigured() {
-		t.Error("OAuthConfigured() = false with build default set; want true")
+	if !googleConfigured() {
+		t.Error("googleConfigured() = false with build default set; want true")
 	}
 	gotID, gotSecret := resolveGoogleClientCreds()
 	if gotID != defaultGoogleClientID || gotSecret != defaultGoogleClientSecret {
@@ -89,14 +81,48 @@ func TestOAuthConfiguredTracksBuildDefault(t *testing.T) {
 }
 
 // TestBeginAuthUnconfigured surfaces an actionable error (not a dead flow)
-// when the server has no Google client.
+// when neither the server nor the instance has a Google client.
 func TestBeginAuthUnconfigured(t *testing.T) {
 	t.Setenv(envGoogleClientID, "")
 	t.Setenv(envGoogleClientSecret, "")
+	origID, origSecret := defaultGoogleClientID, defaultGoogleClientSecret
+	t.Cleanup(func() { defaultGoogleClientID, defaultGoogleClientSecret = origID, origSecret })
+	defaultGoogleClientID, defaultGoogleClientSecret = "", ""
+
 	p := newTestPlugin()
 	_, err := p.BeginAuth(context.Background(), app.Instance{Name: "gmail"})
 	if err == nil {
 		t.Fatal("BeginAuth with no client creds returned nil error; want fallback message")
+	}
+}
+
+// TestBeginAuthWithInstanceCreds uses Advanced-pasted client_id/secret when
+// the server has no Google client — the bring-your-own-client Sign in path.
+func TestBeginAuthWithInstanceCreds(t *testing.T) {
+	t.Setenv(envGoogleClientID, "")
+	t.Setenv(envGoogleClientSecret, "")
+	origID, origSecret := defaultGoogleClientID, defaultGoogleClientSecret
+	t.Cleanup(func() { defaultGoogleClientID, defaultGoogleClientSecret = origID, origSecret })
+	defaultGoogleClientID, defaultGoogleClientSecret = "", ""
+
+	p := newTestPlugin()
+	inst := app.Instance{
+		Name: "gmail",
+		Secrets: app.MapSecrets{
+			"client_id":     "byo.apps.googleusercontent.com",
+			"client_secret": "GOCSPX-byo",
+		},
+	}
+	sess, err := p.BeginAuth(context.Background(), inst)
+	if err != nil {
+		t.Fatalf("BeginAuth with instance creds: %v", err)
+	}
+	defer p.oauth.PollAuth(context.Background(), app.AuthSession{ID: sess.ID}) //nolint:errcheck // drive teardown
+	if sess.Kind != app.AuthKindCallback {
+		t.Errorf("Kind = %q, want %q", sess.Kind, app.AuthKindCallback)
+	}
+	if !strings.Contains(sess.AuthURL, "accounts.google.com") {
+		t.Errorf("consent URL missing Google host: %s", sess.AuthURL)
 	}
 }
 

--- a/pkg/gateway/gmail/plugin.go
+++ b/pkg/gateway/gmail/plugin.go
@@ -10,19 +10,19 @@ import (
 	"github.com/rpuneet/mycel/pkg/oauth"
 )
 
-// plugin implements app.Plugin for Gmail, plus app.OAuthFlow: one-click
-// "Connect with Google" runs a local loopback OAuth flow that mints the
-// refresh token. When the server-side Google client isn't configured the
-// flow reports unavailable (OAuthConfigured) and the UI falls back to the
-// manual client-id/secret/refresh-token paste below.
+// plugin implements app.Plugin for Gmail, plus app.OAuthFlow: "Sign in with
+// Gmail" runs a local loopback OAuth flow that mints the refresh token.
+// The connect UI always offers both paths — browser sign-in and Advanced
+// manual paste of client id / secret / refresh token. One-click uses the
+// server Google client (env or release ldflags) when present; otherwise
+// BeginAuth uses client_id / client_secret the user entered in Advanced.
 type plugin struct {
 	oauth *oauth.LoopbackFlow
 }
 
 var (
-	_ app.Plugin          = (*plugin)(nil)
-	_ app.OAuthFlow       = (*plugin)(nil)
-	_ app.OAuthConfigured = (*plugin)(nil)
+	_ app.Plugin    = (*plugin)(nil)
+	_ app.OAuthFlow = (*plugin)(nil)
 )
 
 func init() {
@@ -43,12 +43,12 @@ func (*plugin) Describe() app.Descriptor {
 			{Key: "interval", Label: "Poll Interval (seconds)", Placeholder: "60"},
 		},
 		Docs: []string{
-			"Fastest path: if this server has a Google OAuth client configured, click \"Sign in with Gmail\" above — mycel opens Google in your browser and stores the token locally, no pasting.",
-			"Manual path (no server client): create OAuth credentials in Google Cloud Console → APIs & Services → Credentials.",
+			"Fastest path: click \"Sign in with Gmail\" — mycel opens Google in your browser and stores the token locally. Official releases (and servers with GOOGLE_OAUTH_CLIENT_ID/SECRET set) need no pasting.",
+			"Bring-your-own client: paste OAuth Client ID + Client Secret under Advanced, then click \"Sign in with Gmail\" — same browser link flow, using your Google Cloud Desktop-app credentials.",
+			"Fully manual: create OAuth credentials in Google Cloud Console → APIs & Services → Credentials, then paste Client ID, Client Secret, and a Refresh Token under Advanced (no browser step).",
 			"Enable the Gmail API for the project, then create an OAuth 2.0 Client ID (type: Desktop app).",
 			"Grant the scopes https://www.googleapis.com/auth/gmail.readonly and https://www.googleapis.com/auth/gmail.send on the consent screen.",
-			"Run the OAuth consent flow once (e.g. via the OAuth Playground with your own client) to obtain a refresh token for offline access.",
-			"Paste the Client ID, Client Secret, and Refresh Token here. mycel builds an offline token source and refreshes access tokens automatically.",
+			"For the fully manual path, run the OAuth consent flow once (e.g. via the OAuth Playground with your own client) to obtain a refresh token for offline access.",
 			"Optionally set a label (default INBOX), a Gmail search query (default is:unread), and a poll interval in seconds (default 60).",
 		},
 	}
@@ -63,12 +63,6 @@ func (p *plugin) BeginAuth(ctx context.Context, inst app.Instance) (app.AuthSess
 // credentials + refresh token for the server to persist to the vault.
 func (p *plugin) PollAuth(ctx context.Context, session app.AuthSession) (app.AuthResult, error) {
 	return p.oauth.PollAuth(ctx, session)
-}
-
-// OAuthConfigured reports whether one-click Google sign-in is available on
-// this server (the GOOGLE_OAUTH_CLIENT_ID/SECRET client is set).
-func (*plugin) OAuthConfigured() bool {
-	return googleConfigured()
 }
 
 func (*plugin) Build(inst app.Instance, _ app.Env) (gateway.NotificationAdapter, error) {

--- a/server/handlers/apps.go
+++ b/server/handlers/apps.go
@@ -643,9 +643,11 @@ type authSessionJSON struct { //nolint:govet // field order matches JSON/API con
 }
 
 // beginOAuth handles POST /api/apps/{name}/auth for OAuth-capable
-// plugins. The optional request body {"config": {...}} carries plain
-// descriptor fields (e.g. oauth_client_id) which are persisted with the
-// instance — auth-first flows create the instance just like pair-first.
+// plugins. The optional request body {"config": {...}} carries descriptor
+// fields which are persisted with the instance — plain fields in
+// preferences, secret fields (e.g. Gmail client_id/client_secret for
+// bring-your-own Sign in) in the vault. Auth-first flows create the
+// instance just like pair-first.
 func (h *AppsHandler) beginOAuth(w http.ResponseWriter, r *http.Request, name string, plugin app.Plugin, flow app.OAuthFlow) {
 	if h.h == nil || h.h.Config == nil {
 		serviceUnavailable(w, r, "workspace", "workspace not available")
@@ -667,8 +669,15 @@ func (h *AppsHandler) beginOAuth(w http.ResponseWriter, r *http.Request, name st
 		}
 	}
 
-	// Merge submitted plain fields over the stored config and persist the
-	// instance, preserving an existing enabled state.
+	fields := make(map[string]app.FieldSpec, len(d.Fields))
+	for _, f := range d.Fields {
+		fields[f.Key] = f
+	}
+
+	// Merge submitted fields over the stored config and persist the
+	// instance, preserving an existing enabled state. Secret fields
+	// (e.g. Gmail client_id/client_secret for bring-your-own Sign in)
+	// go to the vault; plain fields stay in preferences.
 	h.h.ConfigMu.Lock()
 	cfg := h.h.Config
 	existing, exists := cfg.Apps[name]
@@ -676,7 +685,18 @@ func (h *AppsHandler) beginOAuth(w http.ResponseWriter, r *http.Request, name st
 	for k, v := range existing.Config {
 		plain[k] = v
 	}
+	secretVals := make(map[string]string)
 	for k, v := range req.Config {
+		f, known := fields[k]
+		if !known {
+			h.h.ConfigMu.Unlock()
+			httpError(w, "unknown field \""+k+"\" for app "+d.ID, http.StatusBadRequest)
+			return
+		}
+		if f.Secret {
+			secretVals[k] = v
+			continue
+		}
 		if v == "" {
 			delete(plain, k)
 			continue
@@ -690,6 +710,23 @@ func (h *AppsHandler) beginOAuth(w http.ResponseWriter, r *http.Request, name st
 		h.h.ConfigMu.Unlock()
 		httpError(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+	if len(secretVals) > 0 && h.vault == nil {
+		h.h.ConfigMu.Unlock()
+		serviceUnavailable(w, r, "secrets", "secrets vault not available")
+		return
+	}
+	for k, v := range secretVals {
+		vaultKey := app.SecretName(name, k)
+		if v == "" {
+			_ = h.vault.Delete(vaultKey) //nolint:errcheck // absent key is fine
+			continue
+		}
+		if err := h.vault.Set(vaultKey, v, "app credential"); err != nil {
+			h.h.ConfigMu.Unlock()
+			httpInternalError(w, "store secret", err)
+			return
+		}
 	}
 	enabled := true
 	if exists {

--- a/server/handlers/apps_oauth_test.go
+++ b/server/handlers/apps_oauth_test.go
@@ -187,26 +187,45 @@ func TestAppsOAuthBeginPollPersist(t *testing.T) {
 }
 
 func TestAppsOAuthBeginValidatesConfig(t *testing.T) {
-	h, _ := newAppsTestHandler(t)
-
-	tests := []struct {
-		name string
-		body string
-	}{
-		{"secret field in config", `{"config":{"api_token":"x","oauth_client_id":"id"}}`},
-		{"unknown field", `{"config":{"bogus":"x"}}`},
-		{"begin error surfaces (missing client id)", `{}`},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "/api/apps/fakeoauth/auth", strings.NewReader(tt.body))
-			rr := httptest.NewRecorder()
-			h.auth(rr, req, "fakeoauth")
-			if rr.Code != http.StatusBadRequest {
-				t.Errorf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
-			}
-		})
-	}
+	t.Run("secret field vaulted on begin", func(t *testing.T) {
+		// Gmail-style bring-your-own client: secret fields (client_id /
+		// client_secret) may ride on begin so Sign in can mint a token.
+		h, _ := newAppsTestHandler(t)
+		body := `{"config":{"api_token":"preseed","oauth_client_id":"id"}}`
+		req := httptest.NewRequest(http.MethodPost, "/api/apps/fakeoauth/auth", strings.NewReader(body))
+		rr := httptest.NewRecorder()
+		h.auth(rr, req, "fakeoauth")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+		if got, err := h.vault.GetValue("app:fakeoauth:api_token"); err != nil || got != "preseed" {
+			t.Errorf("vault api_token = %q (err %v), want preseed", got, err)
+		}
+		if ic := h.h.Config.Apps["fakeoauth"]; ic.Config["oauth_client_id"] != "id" {
+			t.Errorf("plain config = %+v, want oauth_client_id=id", ic.Config)
+		}
+		if ic := h.h.Config.Apps["fakeoauth"]; ic.Config["api_token"] != "" {
+			t.Errorf("secret leaked into plain config: %+v", ic.Config)
+		}
+	})
+	t.Run("unknown field", func(t *testing.T) {
+		h, _ := newAppsTestHandler(t)
+		req := httptest.NewRequest(http.MethodPost, "/api/apps/fakeoauth/auth", strings.NewReader(`{"config":{"bogus":"x"}}`))
+		rr := httptest.NewRecorder()
+		h.auth(rr, req, "fakeoauth")
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+		}
+	})
+	t.Run("begin error surfaces (missing client id)", func(t *testing.T) {
+		h, _ := newAppsTestHandler(t)
+		req := httptest.NewRequest(http.MethodPost, "/api/apps/fakeoauth/auth", strings.NewReader(`{}`))
+		rr := httptest.NewRecorder()
+		h.auth(rr, req, "fakeoauth")
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+		}
+	})
 }
 
 func TestAppsOAuthStatusRequiresSessionParam(t *testing.T) {

--- a/web/src/components/apps/ConnectApp.tsx
+++ b/web/src/components/apps/ConnectApp.tsx
@@ -750,9 +750,11 @@ export function ConnectWizard({
   };
 
   /** Begin the browser sign-in (OAuth). Plain fields already typed into
-   *  the form (e.g. the OAuth client ID) ride along and persist with the
-   *  instance; the server drives the flow and stores the credentials, so
-   *  on "complete" we advance straight to the agents step. */
+   *  the form (e.g. GitHub oauth_client_id) ride along and persist with the
+   *  instance. For Gmail, Client ID + Client Secret from Advanced are also
+   *  sent so bring-your-own-client Sign in can mint a refresh token via the
+   *  same login link. The server stores vault secrets; on "complete" we
+   *  advance straight to the agents step. */
   const startOAuth = async () => {
     if (!descriptor) return;
     setOauthState("starting");
@@ -760,9 +762,12 @@ export function ConnectWizard({
     try {
       const config: Record<string, string> = {};
       for (const field of descriptor.fields) {
-        if (field.secret) continue;
         const val = (values[field.key] ?? "").trim();
-        if (val !== "") config[field.key] = val;
+        if (val === "") continue;
+        // Skip refresh_token on begin — Sign in is meant to mint it. Other
+        // secrets (client_id / client_secret) are needed for BYO OAuth.
+        if (field.secret && field.key === "refresh_token") continue;
+        config[field.key] = val;
       }
       const session = await api.beginAppOAuth(instanceName, config);
       setOauthSession(session);


### PR DESCRIPTION
## Summary
- Gmail connect always shows **Sign in with Gmail** (browser link) **and** **Advanced** manual Client ID / Secret / Refresh Token.
- Root cause: `OAuthConfigured` set `oauth_available=false` when server Google client env/ldflags were missing, so the UI dropped the link path entirely.
- Begin-auth now vaults Advanced `client_id`/`client_secret` so bring-your-own Google Desktop clients can still use the login-link flow; fully manual refresh-token paste remains.

Fixes #3722. Part of #3714.

## Test plan
- [x] `go test ./pkg/gateway/gmail/ ./server/handlers/ -run 'OAuth|BeginAuth|GoogleConfigured|AppsOAuth'`
- [x] `bun run test -- src/components/apps/__tests__/connectApp.test.tsx`
- [ ] Apps → Connect Gmail: Sign in button visible + Advanced disclosure with fields
- [ ] With `GOOGLE_OAUTH_CLIENT_*` set (or release build): Sign in works zero-paste
- [ ] Without server client: Advanced Client ID+Secret → Sign in still opens Google link; or paste refresh token + Connect


Made with [Cursor](https://cursor.com)